### PR TITLE
test: add connector smoke tests and docs

### DIFF
--- a/docs/connectors/ebay.md
+++ b/docs/connectors/ebay.md
@@ -1,0 +1,19 @@
+# eBay
+
+**Overlay:** `overlays/ebay.product.overlay.json`
+
+**Fixture:** `examples/ebay/product.sample.json`
+
+Maps `title` → `title`, `brand` → `brand`, `ean` → `barcode`.
+
+## Try locally
+
+```bash
+node scripts/map.mjs --source ebay --in examples/ebay/product.sample.json
+```
+
+## Sample input
+
+```json
+--8<-- "examples/ebay/product.sample.json"
+```

--- a/docs/connectors/ifixit.md
+++ b/docs/connectors/ifixit.md
@@ -1,0 +1,19 @@
+# iFixit
+
+**Overlay:** `overlays/ifixit.product.overlay.json`
+
+**Fixture:** `examples/ifixit/product.sample.json`
+
+Maps `name` → `title`, `manufacturer` → `brand`, `sku` → `barcode`.
+
+## Try locally
+
+```bash
+node scripts/map.mjs --source ifixit --in examples/ifixit/product.sample.json
+```
+
+## Sample input
+
+```json
+--8<-- "examples/ifixit/product.sample.json"
+```

--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -1,0 +1,8 @@
+# Connector Smoke Tests
+
+Intro overview of connectors providing sample mappings into the universal product schema.
+
+- [Open Food Facts](off.md)
+- [iFixit](ifixit.md)
+- [eBay](ebay.md)
+- [Library of Things](lot.md)

--- a/docs/connectors/lot.md
+++ b/docs/connectors/lot.md
@@ -1,0 +1,19 @@
+# Library of Things
+
+**Overlay:** `overlays/lot.product.overlay.json`
+
+**Fixture:** `examples/lot/product.sample.json`
+
+Maps `itemName` → `title`, `organisation` → `brand`, `barcode` → `barcode`.
+
+## Try locally
+
+```bash
+node scripts/map.mjs --source lot --in examples/lot/product.sample.json
+```
+
+## Sample input
+
+```json
+--8<-- "examples/lot/product.sample.json"
+```

--- a/docs/connectors/off.md
+++ b/docs/connectors/off.md
@@ -1,0 +1,19 @@
+# Open Food Facts
+
+**Overlay:** `overlays/off.product.overlay.json`
+
+**Fixture:** `examples/off/product.sample.json`
+
+Maps `product_name` → `title`, `brands` → `brand`, `code` → `barcode`.
+
+## Try locally
+
+```bash
+node scripts/map.mjs --source off --in examples/off/product.sample.json
+```
+
+## Sample input
+
+```json
+--8<-- "examples/off/product.sample.json"
+```

--- a/examples/ebay/product.sample.json
+++ b/examples/ebay/product.sample.json
@@ -1,0 +1,5 @@
+{
+  "title": "Vintage Camera",
+  "brand": "Canon",
+  "ean": "0987654321"
+}

--- a/examples/ifixit/product.sample.json
+++ b/examples/ifixit/product.sample.json
@@ -1,0 +1,5 @@
+{
+  "name": "iFixit Pro Tech Toolkit",
+  "manufacturer": "iFixit",
+  "sku": "1234567890"
+}

--- a/examples/lot/product.sample.json
+++ b/examples/lot/product.sample.json
@@ -1,0 +1,5 @@
+{
+  "itemName": "Cordless Drill",
+  "organisation": "Library of Things",
+  "barcode": "1122334455"
+}

--- a/examples/off/product.sample.json
+++ b/examples/off/product.sample.json
@@ -1,12 +1,12 @@
 {
-  "title": "M&M's Peanut",
-  "brand": "Mars",
-  "barcode": "737628064502",
+  "code": "737628064502",
+  "product_name": "M&M's Peanut",
+  "brands": "Mars",
   "quantity": "49 g",
   "categories": "Snacks, Sweet snacks, Chocolate snacks",
   "image_url": "https://static.openfoodfacts.org/images/products/737/628/064/502/front_en.3.400.jpg",
   "ingredients_text": "Peanuts, sugar, chocolate, skim milk, cocoa butter",
   "nutriscore_grade": "d",
   "ecoscore_grade": "e",
-  "provenance_source": "https://world.openfoodfacts.org/product/737628064502"
+  "url": "https://world.openfoodfacts.org/product/737628064502"
 }

--- a/overlays/ebay.product.overlay.json
+++ b/overlays/ebay.product.overlay.json
@@ -1,0 +1,5 @@
+{
+  "title": "title",
+  "brand": "brand",
+  "barcode": "ean"
+}

--- a/overlays/ifixit.product.overlay.json
+++ b/overlays/ifixit.product.overlay.json
@@ -1,0 +1,5 @@
+{
+  "title": "name",
+  "brand": "manufacturer",
+  "barcode": "sku"
+}

--- a/overlays/lot.product.overlay.json
+++ b/overlays/lot.product.overlay.json
@@ -1,0 +1,5 @@
+{
+  "title": "itemName",
+  "brand": "organisation",
+  "barcode": "barcode"
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
     "map:off": "node scripts/off-map.mjs",
     "schema:validate": "for s in schemas/**/*.json; do for d in examples/**/*.json; do ajv validate --spec=draft2020 --all-errors --strict=false --validate-formats=false -s \"$s\" -d \"$d\"; done; done",
     "generate:examples": "npm run map:off && npm run schema:validate",
-    "docs:build": "mkdocs build --strict"
+    "docs:build": "mkdocs build --strict",
+    "test:connectors": "node tests/run_all.mjs",
+    "test:off": "node tests/test_off.mjs",
+    "test:ifixit": "node tests/test_ifixit.mjs",
+    "test:ebay": "node tests/test_ebay.mjs",
+    "test:lot": "node tests/test_lot.mjs"
   },
   "devDependencies": {
     "@stoplight/spectral-cli": "^6.15.0",

--- a/scripts/map.mjs
+++ b/scripts/map.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Ajv from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      out[key] = argv[++i];
+    }
+  }
+  return out;
+}
+
+function get(obj, dotted) {
+  return dotted.split('.').reduce((o, k) => (o ? o[k] : undefined), obj);
+}
+
+function set(obj, dotted, value) {
+  const parts = dotted.split('.');
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    cur = cur[parts[i]] || (cur[parts[i]] = {});
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const {
+    source,
+    in: inFile,
+    schema = path.join(ROOT, 'schemas', 'universal', 'product.schema.json'),
+    overlay = source && path.join(ROOT, 'overlays', `${source}.product.overlay.json`),
+    out,
+  } = args;
+
+  if (!source || !inFile) {
+    console.error('usage: --source <id> --in <file>');
+    process.exit(2);
+  }
+
+  let raw;
+  try {
+    raw = JSON.parse(fs.readFileSync(inFile, 'utf8'));
+  } catch (e) {
+    console.error(`cannot read input file: ${e.message}`);
+    process.exit(2);
+  }
+
+  let overlayMap;
+  let schemaJson;
+  try {
+    overlayMap = JSON.parse(fs.readFileSync(overlay, 'utf8'));
+    schemaJson = JSON.parse(fs.readFileSync(schema, 'utf8'));
+  } catch (e) {
+    console.error(`missing schema/overlay: ${e.message}`);
+    process.exit(2);
+  }
+
+  const mapped = {};
+  for (const [target, sourcePath] of Object.entries(overlayMap)) {
+    const val = get(raw, sourcePath);
+    if (val !== undefined && val !== null && val !== '') {
+      set(mapped, target, val);
+    }
+  }
+
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schemaJson);
+  const valid = validate(mapped);
+  if (!valid) {
+    for (const err of validate.errors) {
+      const loc = err.instancePath || '$';
+      console.error(`${loc} ${err.message}`);
+    }
+    process.exit(1);
+  }
+
+  if (out) {
+    fs.writeFileSync(out, JSON.stringify(mapped, null, 2));
+  } else {
+    process.stdout.write(JSON.stringify(mapped, null, 2));
+  }
+  process.exit(0);
+}
+
+main();

--- a/tests/helpers/runMapValidate.mjs
+++ b/tests/helpers/runMapValidate.mjs
@@ -1,0 +1,33 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import Ajv from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const ROOT = path.join(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+
+export function runMapValidate(source, fixture) {
+  const cmd = ['scripts/map.mjs', '--source', source, '--in', fixture];
+  const res = spawnSync('node', cmd, { encoding: 'utf8' });
+  if (res.status !== 0) {
+    throw new Error(`map.mjs failed for ${source}: ${res.stderr}`);
+  }
+  let output;
+  try {
+    output = JSON.parse(res.stdout);
+  } catch {
+    throw new Error('invalid JSON output');
+  }
+  const schema = JSON.parse(
+    fs.readFileSync(path.join(ROOT, 'schemas', 'universal', 'product.schema.json'), 'utf8')
+  );
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(output);
+  if (!valid) {
+    throw new Error(ajv.errorsText(validate.errors));
+  }
+  console.log(`[${source}] OK`);
+}

--- a/tests/run_all.mjs
+++ b/tests/run_all.mjs
@@ -1,0 +1,17 @@
+import { spawnSync } from 'node:child_process';
+
+const tests = [
+  'tests/test_off.mjs',
+  'tests/test_ifixit.mjs',
+  'tests/test_ebay.mjs',
+  'tests/test_lot.mjs'
+];
+
+for (const t of tests) {
+  const res = spawnSync('node', [t], { stdio: 'inherit' });
+  if (res.status !== 0) {
+    process.exit(res.status || 1);
+  }
+}
+
+console.log('All connector smoke tests passed ✅');

--- a/tests/test_ebay.mjs
+++ b/tests/test_ebay.mjs
@@ -1,0 +1,3 @@
+import { runMapValidate } from './helpers/runMapValidate.mjs';
+
+await runMapValidate('ebay', 'examples/ebay/product.sample.json');

--- a/tests/test_ifixit.mjs
+++ b/tests/test_ifixit.mjs
@@ -1,0 +1,3 @@
+import { runMapValidate } from './helpers/runMapValidate.mjs';
+
+await runMapValidate('ifixit', 'examples/ifixit/product.sample.json');

--- a/tests/test_lot.mjs
+++ b/tests/test_lot.mjs
@@ -1,0 +1,3 @@
+import { runMapValidate } from './helpers/runMapValidate.mjs';
+
+await runMapValidate('lot', 'examples/lot/product.sample.json');

--- a/tests/test_off.mjs
+++ b/tests/test_off.mjs
@@ -1,0 +1,3 @@
+import { runMapValidate } from './helpers/runMapValidate.mjs';
+
+await runMapValidate('off', 'examples/off/product.sample.json');


### PR DESCRIPTION
## Summary
- add generic `map.mjs` and overlay fixtures
- add smoke tests for OFF, iFixit, eBay, Library of Things
- document connector mappings with sample inputs

## Testing
- `node tests/run_all.mjs`
- `npm run docs:build` *(fails: Aborted with 1 warnings in strict mode)*

------
https://chatgpt.com/codex/tasks/task_e_68bce0bf522c8321862aae9305abf140