### PR TITLE
feat(contracts): freeze universal v1 and add mocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: changelog docs setup validate test smoke test-connectors
+.PHONY: changelog docs setup validate test smoke test-connectors test-contracts
 
 changelog:
 	. .venv/bin/activate && cz changelog --unreleased
@@ -10,7 +10,7 @@ setup:
 	python -m venv .venv && . .venv/bin/activate && pip install -U pip && pip install -r requirements.txt && npm ci
 
 validate:
-	npm run schema:validate
+	python scripts/validate_schemas.py
 
 test:
 	pytest -q
@@ -20,3 +20,6 @@ smoke:
 
 test-connectors:
 	pytest -q tests/connectors/off
+
+test-contracts:
+	$(MAKE) validate

--- a/PROJECT_CHANGELOG.md
+++ b/PROJECT_CHANGELOG.md
@@ -14,6 +14,7 @@
 - web: alias react-native to react-native-web and simplify shared UI to React Native primitives; files: apps/web/next.config.mjs, apps/web/tsconfig.json, packages/ui/\*; follow-up: audit Next ESLint plugin
 - ci: ignore pnpm lockfile and fix require-changelog workflow so YAML lint passes; files: .yamllint.yaml, .github/workflows/require-changelog.yml; follow-up: monitor YAML lint
 - connectors/off: add feature-flagged OFF adapter emitting universal v1; adds CLI and schema validation tests; follow-up: integrate into unified search
+- feat(contracts): freeze universal v1 + seed UI-readable mocks; files: schemas/universal/search-result.v1.json, openapi/circl.openapi.yaml, mocks/search.sample.json; follow-up: add validation tests
 
 ## 2025-09-07
 

--- a/docs/contracts/universal-v1.md
+++ b/docs/contracts/universal-v1.md
@@ -1,0 +1,9 @@
+# Universal Schema v1
+
+`schemas/universal/*.v1.json` defines the frozen baseline contracts shared across
+connectors and the UI.
+
+## Versioning
+
+- `v1` is immutable; only additive, backward-compatible fields may appear in `v1.x` files.
+- Breaking changes require a new schema file with a bumped version (e.g., `search-result.v1.1.json`) plus corresponding docs and OpenAPI updates.

--- a/mocks/search.sample.json
+++ b/mocks/search.sample.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "result-1",
+    "title": "Refurbished Laptop",
+    "summary": "Upgraded and tested, 1-year warranty.",
+    "score": 0.87,
+    "dataSource": ["ebay"],
+    "badges": ["used", "warranty"],
+    "url": "https://example.com/laptop",
+    "product": { "sku": "A1" },
+    "company": { "name": "Example Store" }
+  }
+]

--- a/openapi/circl.openapi.yaml
+++ b/openapi/circl.openapi.yaml
@@ -35,6 +35,12 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: ../schemas/universal/search-result.v1.json
 
   /products/{id}:
     get:

--- a/schemas/universal/search-result.v1.json
+++ b/schemas/universal/search-result.v1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://circl.dev/schemas/search-result.v1.json",
+  "title": "Search Result v1",
+  "type": "object",
+  "required": ["id", "title", "summary", "score", "dataSource", "badges"],
+  "properties": {
+    "id": { "type": "string" },
+    "title": { "type": "string" },
+    "summary": { "type": "string" },
+    "score": { "type": "number" },
+    "dataSource": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "badges": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "url": { "type": "string", "format": "uri" },
+    "product": { "type": "object" },
+    "company": { "type": "object" }
+  },
+  "examples": [
+    {
+      "id": "result-1",
+      "title": "Refurbished Laptop",
+      "summary": "Upgraded and tested, 1-year warranty.",
+      "score": 0.87,
+      "dataSource": ["ebay"],
+      "badges": ["used", "warranty"],
+      "url": "https://example.com/laptop",
+      "product": { "sku": "A1" },
+      "company": { "name": "Example Store" }
+    }
+  ]
+}

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Validate JSON Schemas and OpenAPI specs.
+
+This script ensures our contract files stay healthy by running:
+- jsonschema structural checks plus example validation for each schema
+- Spectral lint against any OpenAPI documents
+
+It is intentionally lightweight so `make validate` remains fast and CI-friendly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import subprocess
+
+from jsonschema import Draft202012Validator
+
+SCHEMA_DIR = Path("schemas/universal")
+OPENAPI_DIR = Path("openapi")
+
+
+def validate_json_schemas() -> None:
+    """Check schema structure and validate embedded examples.
+
+    We iterate over each schema file to catch structural errors early and
+    confirm that documented examples remain in sync with the contract.
+    """
+    for schema_path in SCHEMA_DIR.glob("*.json"):
+        schema = json.loads(schema_path.read_text())
+        Draft202012Validator.check_schema(schema)
+        validator = Draft202012Validator(schema)
+        for example in schema.get("examples", []):
+            validator.validate(example)
+
+
+def validate_openapi() -> None:
+    """Run Spectral lint on each OpenAPI spec if present."""
+    for spec in OPENAPI_DIR.glob("*.yaml"):
+        # `npx` resolves the locally installed spectral CLI.
+        subprocess.run(["npx", "spectral", "lint", str(spec)], check=True)
+
+
+def main() -> None:
+    validate_json_schemas()
+    validate_openapi()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add search result v1 schema and OpenAPI response
- seed search mock data and document universal schema versioning
- add schema/OpenAPI validation script and Makefile targets

## Testing
- `make validate`
- `make test-contracts`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68bdb0f9c588832187f37711fc0d2691