### PR TITLE
docs: document changelog fragment workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Summary
+
+<!-- Summary of the changes -->
+
+## Changelog
+
+- [ ] Add `/changelog.d/<short-title>.md`
+- [ ] Or label this PR as `no-changelog`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,3 +6,5 @@
 
 - [ ] Add `/changelog.d/<short-title>.md`
 - [ ] Or label this PR as `no-changelog`
+
+<!-- See docs/contributing/changelog.md for fragment style -->

--- a/AGENT.md
+++ b/AGENT.md
@@ -5,9 +5,9 @@
 
 ## Changelog
 
-- **Never** modify `CHANGELOG.md` directly.
-- For each PR, add a short fragment under `changelog.d/` describing the change.
-- If no entry is needed, label the PR `no-changelog`.
-- Example fragments:
-  - `changelog.d/add-off-connector.md` → `feat: add Open Food Facts connector`
-  - `changelog.d/fix-typo.md` → `fix: correct typo in docs`
+ - **Never** modify `CHANGELOG.md` directly.
+ - For each PR, add a fragment under `changelog.d/` summarising the change in one or two lines using Conventional Commit style.
+ - If no entry is needed, label the PR `no-changelog`.
+ - Example fragments:
+   - `changelog.d/add-off-connector.md` → `feat: add Open Food Facts connector`
+   - `changelog.d/fix-typo.md` → `fix: correct typo in docs`

--- a/AGENT.md
+++ b/AGENT.md
@@ -5,9 +5,9 @@
 
 ## Changelog
 
- - **Never** modify `CHANGELOG.md` directly.
- - For each PR, add a fragment under `changelog.d/` summarising the change in one or two lines using Conventional Commit style.
- - If no entry is needed, label the PR `no-changelog`.
- - Example fragments:
-   - `changelog.d/add-off-connector.md` → `feat: add Open Food Facts connector`
-   - `changelog.d/fix-typo.md` → `fix: correct typo in docs`
+- **Never** modify `CHANGELOG.md` directly.
+- For each PR, add a fragment under `changelog.d/` summarizing the change in one line using Conventional Commit style (no trailing period).
+- If no entry is needed, label the PR `no-changelog`.
+- Example fragments:
+  - `changelog.d/add-off-connector.md` → `feat: add Open Food Facts connector`
+  - `changelog.d/fix-typo.md` → `fix: correct typo in docs`

--- a/AGENT.md
+++ b/AGENT.md
@@ -2,3 +2,12 @@
 
 - [Agent Brief](docs/ops/AGENT-BRIEF.md)
 - [Context Pack](docs/ops/CONTEXT-PACK.md)
+
+## Changelog
+
+- **Never** modify `CHANGELOG.md` directly.
+- For each PR, add a short fragment under `changelog.d/` describing the change.
+- If no entry is needed, label the PR `no-changelog`.
+- Example fragments:
+  - `changelog.d/add-off-connector.md` → `feat: add Open Food Facts connector`
+  - `changelog.d/fix-typo.md` → `fix: correct typo in docs`

--- a/CONTEXT-PACK.md
+++ b/CONTEXT-PACK.md
@@ -15,3 +15,4 @@ Conventions:
 
 - Code in TypeScript/Node/Next.js, JSON Schema 2020-12, OpenAPI 3.1
 - Always update docs + ADRs when changing behavior or decisions
+- Use changelog fragments: add `/changelog.d/<short-title>.md` per PR; CI blocks direct edits to `CHANGELOG.md`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ mkdocs serve
 ## Changelog
 
 - Do not edit `CHANGELOG.md` directly.
-- For each PR, add a fragment under `changelog.d/` summarising the change in one or two lines using Conventional Commit style (e.g., `changelog.d/add-off-connector.md`).
+- For each PR, add a fragment under `changelog.d/` summarizing the change in one or two lines using Conventional Commit style (e.g., `changelog.d/add-off-connector.md`).
 - If no entry is needed, label the PR `no-changelog`.
 - During release, fragments are compiled into `CHANGELOG.md` and then cleared.
+- See [docs/contributing/changelog.md](docs/contributing/changelog.md) for details.

--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ mkdocs serve
   then `mkdocs build`
 - Without token (forks/offline):
   `mkdocs build -f mkdocs.nocommitters.yml`
+
+## Changelog
+
+- Do not edit `CHANGELOG.md` directly.
+- For each PR, add a short fragment under `changelog.d/` (e.g., `changelog.d/add-off-connector.md`).
+- If no entry is needed, label the PR `no-changelog`.
+- During release, fragments are compiled into `CHANGELOG.md` and then cleared.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ mkdocs serve
 ## Changelog
 
 - Do not edit `CHANGELOG.md` directly.
-- For each PR, add a short fragment under `changelog.d/` (e.g., `changelog.d/add-off-connector.md`).
+- For each PR, add a fragment under `changelog.d/` summarising the change in one or two lines using Conventional Commit style (e.g., `changelog.d/add-off-connector.md`).
 - If no entry is needed, label the PR `no-changelog`.
 - During release, fragments are compiled into `CHANGELOG.md` and then cleared.

--- a/docs/contributing/changelog.md
+++ b/docs/contributing/changelog.md
@@ -1,7 +1,7 @@
 # Changelog fragments
 
 - Never edit `CHANGELOG.md` directly.
-- For each PR, add a fragment under `changelog.d/` summarising the change in one or two lines using Conventional Commit style.
+- For each PR, add a fragment under `changelog.d/` summarizing the change in one line using Conventional Commit style (no trailing period).
 - Name fragments descriptively, e.g. `add-off-connector.md`.
 - If no entry is needed, label the PR `no-changelog`.
 - During release, fragments are compiled into `CHANGELOG.md` and then removed.

--- a/docs/contributing/changelog.md
+++ b/docs/contributing/changelog.md
@@ -1,0 +1,7 @@
+# Changelog fragments
+
+- Never edit `CHANGELOG.md` directly.
+- For each PR, add a fragment under `changelog.d/` summarising the change in one or two lines.
+- Name fragments descriptively, e.g. `add-off-connector.md`.
+- If no entry is needed, label the PR `no-changelog`.
+- During release, fragments are compiled into `CHANGELOG.md` and then removed.

--- a/docs/contributing/changelog.md
+++ b/docs/contributing/changelog.md
@@ -1,7 +1,7 @@
 # Changelog fragments
 
 - Never edit `CHANGELOG.md` directly.
-- For each PR, add a fragment under `changelog.d/` summarising the change in one or two lines.
+- For each PR, add a fragment under `changelog.d/` summarising the change in one or two lines using Conventional Commit style.
 - Name fragments descriptively, e.g. `add-off-connector.md`.
 - If no entry is needed, label the PR `no-changelog`.
 - During release, fragments are compiled into `CHANGELOG.md` and then removed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
           - process/605-ai-collaboration.md
           - process/610-contributing.md
           - process/620-versioning-release.md
+          - contributing/changelog.md
   - Changelog: changelog/index.md
   - Architecture:
       - ADRs: adr/index.md


### PR DESCRIPTION
## Summary
- document changelog fragment workflow for contributors and agents
- add PR template requiring changelog fragment or `no-changelog` label

## Changelog
- [ ] Add `/changelog.d/<short-title>.md`
- [x] Or label this PR as `no-changelog`


------
https://chatgpt.com/codex/tasks/task_e_68bdb4642adc83219ba42b075e9e442d