### PR TITLE
docs: move changelog entries to fragment

### DIFF
--- a/changelog.d/20250907-work.md
+++ b/changelog.d/20250907-work.md
@@ -1,0 +1,7 @@
+### Feat
+
+- add OFF mapping script and universal example
+
+### Fix
+
+- **ci**: wrap workflow lines for yamllint

--- a/changelog.d/20250907-work.md
+++ b/changelog.d/20250907-work.md
@@ -1,7 +1,9 @@
-### Feat
+# Changelog
+
+## Feat
 
 - add OFF mapping script and universal example
 
-### Fix
+## Fix
 
 - **ci**: wrap workflow lines for yamllint


### PR DESCRIPTION
## Summary
- replace direct CHANGELOG.md edits with a dated fragment

## Testing
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68bdb471c21c8321a8771c62a624ea6a