### PR TITLE
docs: document changelog fragment workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,5 @@
 - 
 
 ## Changelog
-- [ ] Add a fragment in `changelog.d/`
-- [ ] Or add the `no-changelog` label for docs-only or CI-only changes
+- [ ] Add `/changelog.d/<short-title>.md` with a one-line summary
+- [ ] Or apply the `no-changelog` label for docs-only or CI-only changes

--- a/AGENT.md
+++ b/AGENT.md
@@ -2,4 +2,8 @@
 
 - [Agent Brief](docs/ops/AGENT-BRIEF.md)
 - [Context Pack](docs/ops/CONTEXT-PACK.md)
-- Do not edit `CHANGELOG.md` directly. Add a fragment in `changelog.d/` instead; the release workflow compiles them.
+- **NEVER** modify `CHANGELOG.md` directly.
+  - For every PR add `/changelog.d/<short-title>.md` describing the change in one or two lines.
+  - Example filenames: `123-add-repair-connector.md`, `fix-typo.md`.
+  - Fragment style: `feat: add repair connector (#123)`.
+  - If no entry is needed, apply the `no-changelog` label.

--- a/CONTEXT-PACK.md
+++ b/CONTEXT-PACK.md
@@ -15,3 +15,5 @@ Conventions:
 
 - Code in TypeScript/Node/Next.js, JSON Schema 2020-12, OpenAPI 3.1
 - Always update docs + ADRs when changing behavior or decisions
+- Never edit `CHANGELOG.md` directly; add `/changelog.d/<short-title>.md` and let CI compile.
+  CI guards reject direct edits without a fragment or `no-changelog` label.

--- a/README.md
+++ b/README.md
@@ -24,4 +24,9 @@ mkdocs serve
   `mkdocs build -f mkdocs.nocommitters.yml`
 
 ### Changelog
-Do not edit `CHANGELOG.md` directly. Add a short fragment in `changelog.d/`. The release workflow compiles fragments into the main changelog.
+Each PR must either:
+
+1. Add `/changelog.d/<short-title>.md` with a one-line summary, or
+2. Apply the `no-changelog` label for docs/CI-only changes.
+
+The release workflow compiles fragments into `CHANGELOG.md` and clears the directory.

--- a/changelog.d/docs-changelog-fragments.md
+++ b/changelog.d/docs-changelog-fragments.md
@@ -1,0 +1,1 @@
+- docs: document changelog fragment workflow

--- a/docs/contributing/changelog.md
+++ b/docs/contributing/changelog.md
@@ -1,6 +1,6 @@
 # Changelog fragments
 
-Each pull request should include a short fragment in `changelog.d/` instead of editing `CHANGELOG.md` directly. This avoids merge conflicts.
+Each pull request should include a short fragment in `changelog.d/` instead of editing `CHANGELOG.md` directly. This avoids merge conflicts and keeps the history clear.
 
 ## How to add a fragment
 
@@ -8,5 +8,6 @@ Each pull request should include a short fragment in `changelog.d/` instead of e
 2. Add a brief bullet describing the change, for example:
    - `feat: add recycling connector (#123)`
 3. Commit the file with the rest of your changes.
+4. For docs-only or CI-only updates, apply the `no-changelog` label instead of adding a fragment.
 
-During releases, `scripts/compile_changelog.py` stitches these fragments into the main `CHANGELOG.md`.
+CI checks fail if `CHANGELOG.md` is edited directly or a fragment is missing. During releases, `scripts/compile_changelog.py` stitches these fragments into the main `CHANGELOG.md` and clears the directory.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,5 +89,6 @@ nav:
       - ADRs: adr/index.md
   - Releases: releases.md
   - Contributing:
+      # Guide on changelog fragments for PRs
       - Changelog fragments: contributing/changelog.md
 


### PR DESCRIPTION
## Summary
- clarify changelog fragment rules for agents and contributors
- document fragment workflow in README and docs
- require fragment file or `no-changelog` label in PR template

## Testing
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68bdba1ca6a4832194f225168b0417eb