### PR TITLE
chore: add test-web target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: changelog docs setup validate test smoke test-connectors test-contracts
+.PHONY: changelog docs setup validate lint test test-web smoke test-connectors test-contracts
 
 changelog:
 	. .venv/bin/activate && cz changelog --unreleased
@@ -12,8 +12,14 @@ setup:
 validate:
 	python scripts/validate_schemas.py
 
+lint:
+	pnpm lint
+
 test:
 	pytest -q
+
+test-web:
+	pnpm -C ui test
 
 smoke:
 	./tools/ingest_and_map.py --source off --barcode 737628064502 --out /tmp/off-mapped.json && head -n 30 /tmp/off-mapped.json

--- a/changelog.d/test-web-target.md
+++ b/changelog.d/test-web-target.md
@@ -1,0 +1,1 @@
+chore: add test-web target to Makefile


### PR DESCRIPTION
## Summary
- add test-web and lint make targets
- document test-web target in changelog

## Testing
- `pnpm --dir ui install --ignore-workspace` *(fails: No package.json found)*
- `pnpm -C ui build` *(fails: No package.json found)*
- `pnpm -C ui test` *(fails: No package.json found)*
- `make test`
- `make test-web` *(fails: No package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc26a920083219ce62ece4ef98e51