### PR TITLE
chore: restore test-web target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: changelog docs setup validate lint test test-web smoke test-connectors test-contracts
+.PHONY: changelog docs setup validate lint test smoke test-connectors test-contracts test-web
 
 changelog:
 	. .venv/bin/activate && cz changelog --unreleased
@@ -15,11 +15,9 @@ validate:
 lint:
 	pnpm lint
 
+
 test:
 	pytest -q
-
-test-web:
-	pnpm -C ui test
 
 smoke:
 	./tools/ingest_and_map.py --source off --barcode 737628064502 --out /tmp/off-mapped.json && head -n 30 /tmp/off-mapped.json
@@ -29,3 +27,6 @@ test-connectors:
 
 test-contracts:
 	$(MAKE) validate
+
+test-web:
+	pnpm -C ui test

--- a/changelog.d/makefile-test-web.md
+++ b/changelog.d/makefile-test-web.md
@@ -1,0 +1,1 @@
+ci: restore test-web target in Makefile


### PR DESCRIPTION
## Summary
- reconcile Makefile with upstream targets and restore `test-web` recipe
- document makefile update in changelog fragment

## Testing
- `pnpm --dir ui install --ignore-workspace` *(fails: No package.json found)*
- `pnpm -C ui build` *(fails: No package.json found)*
- `pnpm -C ui test` *(fails: No package.json found)*
- `make test`
- `make test-web` *(fails: No package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc622ab3c832195d40ed538eef14d