### PR TITLE
chore: add merge safeguards and queue docs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec ../scripts/pre-commit.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,15 @@ Use GitHub's merge queue. Enable auto-merge after all required checks and review
 
 ## git worktree for parallel branches
 Use `git worktree add ../<dir> <branch>` to work on multiple branches simultaneously without switching checkouts.
+
+## Local git setup
+Configure git to simplify conflict resolution and to activate repo hooks:
+
+```sh
+git config --global rerere.enabled true     # reuse recorded conflict resolutions
+git config --global pull.rebase true        # keep history linear
+git config --global merge.conflictStyle zdiff3  # show base during merges
+git config core.hooksPath .githooks         # enable pre-commit safeguards
+```
+
+The top-level `Makefile` is intentionally stable; edit files under `make/*.mk` instead.

--- a/changelog/pre-commit-hooks.md
+++ b/changelog/pre-commit-hooks.md
@@ -1,0 +1,1 @@
+ci: add pre-commit hook and merge queue docs

--- a/docs/maintainers/merge-queue.md
+++ b/docs/maintainers/merge-queue.md
@@ -1,0 +1,15 @@
+# Merge queue
+
+GitHub's merge queue serialises merges to `main` so each change lands with a green build.
+
+## Enable on `main`
+1. Navigate to **Settings → Branches** in the repository.
+2. Add or edit the protection rule for `main`.
+3. Check **Require a pull request before merging** and **Require merge queue**.
+4. Under **Require status checks to pass**, add:
+   - `CI`
+   - `Cross-Platform CI`
+   - `require changelog fragment`
+5. Save the rule.
+
+The queue will run the listed checks on each candidate commit and merge sequentially once they pass.

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Pre-commit safeguard to keep high-churn files stable.
+# Fails when the changelog or monolithic Makefile are edited directly so
+# contributors add fragments and touch modular makefiles instead.
+set -euo pipefail
+
+# Gather staged files.
+staged=$(git diff --cached --name-only)
+
+# Prevent direct edits to the aggregated changelog.
+if echo "$staged" | grep -q '^PROJECT_CHANGELOG.md$'; then
+  echo 'Do not edit PROJECT_CHANGELOG.md directly. Add a fragment under /changelog/.' >&2
+  exit 1
+fi
+
+# Encourage modular Makefile changes.
+if echo "$staged" | grep -q '^Makefile$'; then
+  echo 'Edit files under make/*.mk instead.' >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add pre-commit check blocking direct changelog and Makefile edits
- document local git settings and hook activation
- guide maintainers on enabling GitHub Merge Queue

## Testing
- `scripts/pre-commit.sh`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68bdd25a1c448321acef744d91e03846