### PR TITLE
feat(ui): polish theme and state components

### DIFF
--- a/changelog/PR-UI-07-polish.md
+++ b/changelog/PR-UI-07-polish.md
@@ -1,0 +1,1 @@
+feat: polish theme and add reusable UI states (UI-07)

--- a/ui/README.md
+++ b/ui/README.md
@@ -12,3 +12,19 @@ VITE_ENABLE_MOCK_SEARCH=true pnpm -C ui test
 ```
 
 Mock results are served from `public/mocks/search.sample.json`.
+
+## Theme and reusable states
+
+This package uses Tailwind with a Circl theme:
+
+- `primary` – brand green
+- `bg`, `surface`, `soft-border` – background tokens
+- `ok`, `warn`, `bad` – status colors
+
+Available building blocks:
+
+- `<Skeleton variant="rows|cards" />`
+- `<EmptyState icon title description action?>`
+- `<ErrorState title description onRetry?>`
+
+See Storybook stories under `src/components/*.stories.tsx` for examples.

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "lucide-react": "^0.344.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3"
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.2.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.2.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  lucide-react:
+    specifier: ^0.344.0
+    version: 0.344.0(react@18.3.1)
   react:
     specifier: ^18.2.0
     version: 18.3.1
@@ -22,6 +25,9 @@ devDependencies:
   '@testing-library/react':
     specifier: ^14.2.0
     version: 14.3.1(@types/react@18.3.24)(react-dom@18.3.1)(react@18.3.1)
+  '@testing-library/user-event':
+    specifier: ^14.4.3
+    version: 14.6.1(@testing-library/dom@9.3.4)
   '@types/react':
     specifier: ^18.2.21
     version: 18.3.24
@@ -749,6 +755,15 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
+    dev: true
+
+  /@testing-library/user-event@14.6.1(@testing-library/dom@9.3.4):
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+    dependencies:
+      '@testing-library/dom': 9.3.4
     dev: true
 
   /@types/aria-query@5.0.4:
@@ -1639,6 +1654,14 @@ packages:
     dependencies:
       yallist: 3.1.1
     dev: true
+
+  /lucide-react@0.344.0(react@18.3.1):
+    resolution: {integrity: sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.3.1
+    dev: false
 
   /lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,12 +1,15 @@
 import { Route, Routes } from 'react-router-dom';
+import Layout from './components/Layout';
 import Results from './pages/Results';
 import Search from './pages/Search';
 
 export default function App() {
   return (
     <Routes>
-      <Route path="/" element={<Search />} />
-      <Route path="/results" element={<Results />} />
+      <Route element={<Layout />}>
+        <Route path="/" element={<Search />} />
+        <Route path="/results" element={<Results />} />
+      </Route>
     </Routes>
   );
 }

--- a/ui/src/__tests__/home.a11y.test.tsx
+++ b/ui/src/__tests__/home.a11y.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+// Smoke test ensuring focus starts at skip link then search field.
+it('focus order begins with skip link then search', async () => {
+  const App = (await import('../App')).default;
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <App />
+    </MemoryRouter>
+  );
+  const user = userEvent.setup();
+  await user.tab();
+  expect(screen.getByText(/skip to content/i)).toHaveFocus();
+  await user.tab();
+  expect(screen.getByPlaceholderText(/search/i)).toHaveFocus();
+});

--- a/ui/src/components/EmptyState.stories.tsx
+++ b/ui/src/components/EmptyState.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Search } from 'lucide-react';
+import EmptyState from './EmptyState';
+
+const meta: Meta<typeof EmptyState> = {
+  title: 'Components/EmptyState',
+  component: EmptyState,
+};
+export default meta;
+
+export const Basic: StoryObj<typeof EmptyState> = {
+  args: {
+    icon: <Search />,
+    title: 'No results',
+    description: 'Try a different query',
+  },
+};

--- a/ui/src/components/EmptyState.tsx
+++ b/ui/src/components/EmptyState.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+}
+
+// EmptyState conveys absence of data with optional icon and action.
+export default function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+  return (
+    <div className="py-8 text-center" data-testid="empty-state">
+      {icon && <div className="mx-auto mb-4 h-8 w-8 text-primary">{icon}</div>}
+      <h2 className="text-lg font-semibold">{title}</h2>
+      {description && <p className="mt-2 text-sm text-gray-600">{description}</p>}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}

--- a/ui/src/components/ErrorState.stories.tsx
+++ b/ui/src/components/ErrorState.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ErrorState from './ErrorState';
+
+const meta: Meta<typeof ErrorState> = {
+  title: 'Components/ErrorState',
+  component: ErrorState,
+};
+export default meta;
+
+export const Basic: StoryObj<typeof ErrorState> = {
+  args: {
+    title: 'Failed to load',
+    description: 'Please retry',
+  },
+};
+
+export const WithRetry: StoryObj<typeof ErrorState> = {
+  args: {
+    title: 'Error',
+    description: 'Something went wrong',
+    onRetry: () => alert('retry'),
+  },
+};

--- a/ui/src/components/ErrorState.tsx
+++ b/ui/src/components/ErrorState.tsx
@@ -1,4 +1,28 @@
-// ErrorState renders when fetching data fails.
-export default function ErrorState() {
-  return <div>Something went wrong.</div>;
+interface ErrorStateProps {
+  title?: string;
+  description?: string;
+  onRetry?: () => void;
+}
+
+// ErrorState shows an error message and optional retry button.
+export default function ErrorState({
+  title = 'Something went wrong',
+  description = 'Please try again.',
+  onRetry,
+}: ErrorStateProps) {
+  return (
+    <div className="py-8 text-center" data-testid="error-state">
+      <h2 className="text-lg font-semibold text-bad">{title}</h2>
+      {description && <p className="mt-2 text-sm text-gray-600">{description}</p>}
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 rounded border border-soft-border px-4 py-2 text-primary hover:bg-soft-border"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
 }

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -1,0 +1,32 @@
+import { Outlet } from 'react-router-dom';
+
+// Layout provides top-level structure with skip link and footer links.
+export default function Layout() {
+  return (
+    <div className="flex min-h-screen flex-col bg-bg text-gray-900">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-2 focus:rounded focus:bg-surface focus:px-3 focus:py-1 focus:text-primary"
+      >
+        Skip to content
+      </a>
+      <main id="main" className="mx-auto w-full max-w-4xl flex-1 px-4 py-8">
+        <Outlet />
+      </main>
+      <footer className="border-t border-soft-border py-4 text-center text-sm text-gray-600">
+        <a
+          href="/docs"
+          className="mx-2 text-primary hover:underline"
+        >
+          Docs
+        </a>
+        <a
+          href="https://github.com/andremair97/circl"
+          className="mx-2 text-primary hover:underline"
+        >
+          GitHub
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/ui/src/components/Loader.tsx
+++ b/ui/src/components/Loader.tsx
@@ -1,4 +1,0 @@
-// Loader shows a simple loading indicator.
-export default function Loader() {
-  return <div>Loading...</div>;
-}

--- a/ui/src/components/ResultCard.tsx
+++ b/ui/src/components/ResultCard.tsx
@@ -5,18 +5,11 @@ export default function ResultCard({ item }: { item: SearchItem }) {
   return (
     <div
       data-testid="result-card"
-      style={{ border: '1px solid #ccc', padding: '1rem', margin: '0.5rem 0' }}
+      className="my-2 rounded border border-soft-border bg-surface p-4"
     >
-      <h3>{item.title}</h3>
-      <p>{item.description}</p>
-      <span
-        style={{
-          background: '#e0f2f1',
-          padding: '0.25rem 0.5rem',
-          borderRadius: '4px',
-          fontSize: '0.8rem',
-        }}
-      >
+      <h3 className="font-semibold">{item.title}</h3>
+      <p className="text-sm text-gray-700">{item.description}</p>
+      <span className="mt-2 inline-block rounded bg-bg px-2 py-1 text-xs text-gray-600">
         Data source: {item.source}
       </span>
     </div>

--- a/ui/src/components/SearchBar.tsx
+++ b/ui/src/components/SearchBar.tsx
@@ -1,11 +1,14 @@
 import { FormEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import EmptyState from './EmptyState';
+import ErrorState from './ErrorState';
+import Skeleton from './Skeleton';
 import useMockSearch from '../hooks/useMockSearch';
 
-// SearchBar provides a single input with basic typeahead suggestions.
+// SearchBar provides a single input with typeahead suggestions using reusable states.
 export default function SearchBar() {
   const [query, setQuery] = useState('');
-  const { results: suggestions } = useMockSearch(query);
+  const { results: suggestions, loading, error } = useMockSearch(query);
   const navigate = useNavigate();
 
   const handleSubmit = (e: FormEvent) => {
@@ -15,36 +18,30 @@ export default function SearchBar() {
   };
 
   return (
-    <form onSubmit={handleSubmit} style={{ position: 'relative' }}>
+    <form onSubmit={handleSubmit} className="relative">
       <input
         placeholder="Search"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
-        style={{
-          padding: '0.5rem',
-          border: '2px solid #2e7d32',
-          borderRadius: '4px',
-          width: '300px',
-        }}
+        className="w-72 rounded border-2 border-primary px-2 py-1"
       />
-      {suggestions.length > 0 && (
-        <ul
-          style={{
-            position: 'absolute',
-            top: '2.5rem',
-            left: 0,
-            right: 0,
-            background: '#fff',
-            listStyle: 'none',
-            margin: 0,
-            padding: '0.5rem',
-            border: '1px solid #ccc',
-          }}
-        >
-          {suggestions.map((s) => (
-            <li key={s.id}>{s.title}</li>
-          ))}
-        </ul>
+      {query && (
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded border border-soft-border bg-surface p-2 shadow">
+          {loading && <Skeleton count={3} />}
+          {error && <ErrorState title="Error loading" description={error.message} />}
+          {!loading && !error && suggestions.length === 0 && (
+            <EmptyState title="No suggestions" />
+          )}
+          {suggestions.length > 0 && (
+            <ul className="list-none p-0">
+              {suggestions.map((s) => (
+                <li key={s.id} className="px-1 py-0.5 hover:bg-bg">
+                  {s.title}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       )}
     </form>
   );

--- a/ui/src/components/Skeleton.stories.tsx
+++ b/ui/src/components/Skeleton.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Skeleton from './Skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Components/Skeleton',
+  component: Skeleton,
+};
+export default meta;
+
+export const Rows: StoryObj<typeof Skeleton> = {
+  args: { variant: 'rows', count: 3 },
+};
+
+export const Cards: StoryObj<typeof Skeleton> = {
+  args: { variant: 'cards', count: 2 },
+};

--- a/ui/src/components/Skeleton.tsx
+++ b/ui/src/components/Skeleton.tsx
@@ -1,0 +1,31 @@
+interface SkeletonProps {
+  variant?: 'rows' | 'cards';
+  count?: number;
+}
+
+// Skeleton renders placeholder blocks for loading states.
+export default function Skeleton({ variant = 'rows', count = 3 }: SkeletonProps) {
+  const items = Array.from({ length: count });
+  if (variant === 'cards') {
+    return (
+      <div className="grid gap-4" data-testid="skeleton-cards">
+        {items.map((_, i) => (
+          <div
+            key={i}
+            className="h-24 animate-pulse rounded bg-soft-border"
+          />
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2" data-testid="skeleton-rows">
+      {items.map((_, i) => (
+        <div
+          key={i}
+          className="h-4 animate-pulse rounded bg-soft-border"
+        />
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/__tests__/EmptyState.test.tsx
+++ b/ui/src/components/__tests__/EmptyState.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { Search } from 'lucide-react';
+import EmptyState from '../EmptyState';
+
+// Snapshot and rendering test for EmptyState component.
+it('renders icon, text, and action', () => {
+  const { container } = render(
+    <EmptyState
+      icon={<Search data-testid="icon" />}
+      title="No items"
+      description="nothing to see"
+      action={<button>act</button>}
+    />
+  );
+  expect(screen.getByTestId('icon')).toBeInTheDocument();
+  expect(screen.getByText('No items')).toBeInTheDocument();
+  expect(screen.getByText('nothing to see')).toBeInTheDocument();
+  expect(screen.getByText('act')).toBeInTheDocument();
+  expect(container).toMatchSnapshot();
+});

--- a/ui/src/components/__tests__/ErrorState.test.tsx
+++ b/ui/src/components/__tests__/ErrorState.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import ErrorState from '../ErrorState';
+
+// Snapshot and behavior test for ErrorState component.
+it('invokes retry handler when provided', async () => {
+  const retry = vi.fn();
+  const { container } = render(
+    <ErrorState title="oops" description="fail" onRetry={retry} />
+  );
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: /retry/i }));
+  expect(retry).toHaveBeenCalled();
+  expect(container).toMatchSnapshot();
+});

--- a/ui/src/components/__tests__/__snapshots__/EmptyState.test.tsx.snap
+++ b/ui/src/components/__tests__/__snapshots__/EmptyState.test.tsx.snap
@@ -1,0 +1,54 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renders icon, text, and action 1`] = `
+<div>
+  <div
+    class="py-8 text-center"
+    data-testid="empty-state"
+  >
+    <div
+      class="mx-auto mb-4 h-8 w-8 text-primary"
+    >
+      <svg
+        class="lucide lucide-search "
+        data-testid="icon"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="11"
+          cy="11"
+          r="8"
+        />
+        <path
+          d="m21 21-4.3-4.3"
+        />
+      </svg>
+    </div>
+    <h2
+      class="text-lg font-semibold"
+    >
+      No items
+    </h2>
+    <p
+      class="mt-2 text-sm text-gray-600"
+    >
+      nothing to see
+    </p>
+    <div
+      class="mt-4"
+    >
+      <button>
+        act
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/ui/src/components/__tests__/__snapshots__/ErrorState.test.tsx.snap
+++ b/ui/src/components/__tests__/__snapshots__/ErrorState.test.tsx.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`invokes retry handler when provided 1`] = `
+<div>
+  <div
+    class="py-8 text-center"
+    data-testid="error-state"
+  >
+    <h2
+      class="text-lg font-semibold text-bad"
+    >
+      oops
+    </h2>
+    <p
+      class="mt-2 text-sm text-gray-600"
+    >
+      fail
+    </p>
+    <button
+      class="mt-4 rounded border border-soft-border px-4 py-2 text-primary hover:bg-soft-border"
+      type="button"
+    >
+      Retry
+    </button>
+  </div>
+</div>
+`;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,0 +1,14 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Theme tokens as CSS variables for non-Tailwind consumers */
+:root {
+  --color-primary: #2e7d32;
+  --color-bg: #f5f5f4;
+  --color-surface: #ffffff;
+  --color-soft-border: #e5e7eb;
+  --color-ok: #16a34a;
+  --color-warn: #f59e0b;
+  --color-bad: #dc2626;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/ui/src/pages/Results.tsx
+++ b/ui/src/pages/Results.tsx
@@ -1,7 +1,9 @@
 import { useSearchParams } from 'react-router-dom';
+import { Search } from 'lucide-react';
+import EmptyState from '../components/EmptyState';
 import ErrorState from '../components/ErrorState';
-import Loader from '../components/Loader';
 import ResultCard from '../components/ResultCard';
+import Skeleton from '../components/Skeleton';
 import useMockSearch from '../hooks/useMockSearch';
 
 // Results page reads query from URL and displays matching cards.
@@ -10,8 +12,17 @@ export default function Results() {
   const q = params.get('q') || '';
   const { results, loading, error } = useMockSearch(q);
 
-  if (loading) return <Loader />;
-  if (error) return <ErrorState />;
+  if (loading) return <Skeleton variant="cards" count={3} />;
+  if (error) return <ErrorState onRetry={() => location.reload()} />;
+  if (results.length === 0)
+    return (
+      <EmptyState
+        icon={<Search />}
+        title="No results"
+        description="Try a different search term."
+        action={<a href="/" className="text-primary underline">Go back</a>}
+      />
+    );
 
   return (
     <div>

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -1,17 +1,9 @@
 import SearchBar from '../components/SearchBar';
 
-// Landing page with centered SearchBar and green background.
+// Landing page with centered SearchBar and themed background.
 export default function Search() {
   return (
-    <div
-      style={{
-        minHeight: '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: '#e6f4ea',
-      }}
-    >
+    <div className="flex flex-col items-center justify-center py-24">
       <SearchBar />
     </div>
   );

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -1,0 +1,20 @@
+import type { Config } from 'tailwindcss';
+
+// Tailwind configuration providing Circl theme tokens.
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#2e7d32',
+        bg: '#f5f5f4',
+        surface: '#ffffff',
+        'soft-border': '#e5e7eb',
+        ok: '#16a34a',
+        warn: '#f59e0b',
+        bad: '#dc2626',
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
## Summary
- introduce Circl tailwind theme with semantic tokens
- add Layout with footer and skip link and reusable Skeleton/EmptyState/ErrorState components
- apply consistent loading/empty/error states to search results

## Testing
- `pnpm test`
- `pnpm -C ui test`
- `pnpm docs:build` *(fails: Cannot check URL, no Internet access?)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd6980014832198eaf7336bc54a93