### PR TITLE
feat(ui): add pluggable autosuggest provider

### DIFF
--- a/changelog/PR-UI-08-autosuggest-provider.md
+++ b/changelog/PR-UI-08-autosuggest-provider.md
@@ -1,0 +1,1 @@
+feat: make SearchBar suggestions pluggable with local seed provider (#UI-08)

--- a/ui/src/components/SearchBar.stories.tsx
+++ b/ui/src/components/SearchBar.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SearchBar from './SearchBar';
+import LocalSeedProvider from '../suggest/LocalSeedProvider';
+import type { SuggestProvider } from '../suggest/Provider';
+
+const providers: Record<string, SuggestProvider> = {
+  local: new LocalSeedProvider(),
+  empty: { suggest: async () => [] },
+};
+
+const meta: Meta<typeof SearchBar> = {
+  title: 'Components/SearchBar',
+  component: SearchBar,
+  argTypes: {
+    provider: {
+      options: Object.keys(providers),
+      mapping: providers,
+      control: { type: 'radio' },
+    },
+  },
+  args: {
+    provider: providers.local,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SearchBar>;
+
+export const Basic: Story = {};
+
+export const Loading: Story = {
+  args: {
+    provider: {
+      suggest: () => new Promise(() => {}), // never resolves to show loading state
+    },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    provider: providers.empty,
+  },
+};

--- a/ui/src/components/SearchBar.tsx
+++ b/ui/src/components/SearchBar.tsx
@@ -1,20 +1,96 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import EmptyState from './EmptyState';
 import ErrorState from './ErrorState';
 import Skeleton from './Skeleton';
-import useMockSearch from '../hooks/useMockSearch';
+import type { SuggestProvider, Suggestion } from '../suggest/Provider';
 
-// SearchBar provides a single input with typeahead suggestions using reusable states.
-export default function SearchBar() {
-  const [query, setQuery] = useState('');
-  const { results: suggestions, loading, error } = useMockSearch(query);
+interface Props {
+  provider: SuggestProvider;
+}
+
+// SearchBar provides a single input with typeahead suggestions using pluggable providers.
+export default function SearchBar({ provider }: Props) {
   const navigate = useNavigate();
+  const [query, setQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [active, setActive] = useState(-1);
+  const [open, setOpen] = useState(false);
+  const timer = useRef<number>();
+  const controller = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!query) {
+      controller.current?.abort();
+      setSuggestions([]);
+      setOpen(false);
+      return;
+    }
+
+    setOpen(true);
+    window.clearTimeout(timer.current);
+    controller.current?.abort();
+    timer.current = window.setTimeout(async () => {
+      const c = new AbortController();
+      controller.current = c;
+      setLoading(true);
+      try {
+        const res = await provider.suggest(query, c.signal);
+        setSuggestions(res);
+        setError(null);
+      } catch (err: any) {
+        if (err.name !== 'AbortError') setError(err);
+      } finally {
+        setLoading(false);
+      }
+    }, 200);
+
+    return () => {
+      window.clearTimeout(timer.current);
+      controller.current?.abort();
+    };
+  }, [query, provider]);
+
+  const select = (s: Suggestion) => {
+    navigate(`/results?q=${encodeURIComponent(s.title)}&type=${s.type}`);
+    setOpen(false);
+    setActive(-1);
+  };
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
+    if (active >= 0 && suggestions[active]) {
+      select(suggestions[active]);
+      return;
+    }
     if (!query) return;
     navigate(`/results?q=${encodeURIComponent(query)}`);
+    setOpen(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive((i) => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      if (active >= 0 && suggestions[active]) {
+        e.preventDefault();
+        select(suggestions[active]);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+      setActive(-1);
+    }
+  };
+
+  const handleBlur = () => {
+    setOpen(false);
+    setActive(-1);
   };
 
   return (
@@ -23,9 +99,11 @@ export default function SearchBar() {
         placeholder="Search"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
         className="w-72 rounded border-2 border-primary px-2 py-1"
       />
-      {query && (
+      {open && (
         <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded border border-soft-border bg-surface p-2 shadow">
           {loading && <Skeleton count={3} />}
           {error && <ErrorState title="Error loading" description={error.message} />}
@@ -33,9 +111,17 @@ export default function SearchBar() {
             <EmptyState title="No suggestions" />
           )}
           {suggestions.length > 0 && (
-            <ul className="list-none p-0">
-              {suggestions.map((s) => (
-                <li key={s.id} className="px-1 py-0.5 hover:bg-bg">
+            <ul className="list-none p-0" role="listbox">
+              {suggestions.map((s, i) => (
+                <li
+                  key={s.id}
+                  data-testid="suggestion-item"
+                  className={`px-1 py-0.5 hover:bg-bg ${i === active ? 'bg-bg' : ''}`}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    select(s);
+                  }}
+                >
                   {s.title}
                 </li>
               ))}

--- a/ui/src/components/__tests__/SearchBar.test.tsx
+++ b/ui/src/components/__tests__/SearchBar.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { vi } from 'vitest';
+import SearchBar from '../SearchBar';
+import type { SuggestProvider, Suggestion } from '../../suggest/Provider';
+
+describe('SearchBar', () => {
+  it('allows keyboard navigation between suggestions', async () => {
+    const provider: SuggestProvider = {
+      suggest: vi.fn(async () => [
+        { id: '1', title: 'Refurbished Laptop', type: 'product' },
+        { id: '2', title: 'Patagonia', type: 'company' },
+      ]),
+    };
+    render(
+      <MemoryRouter>
+        <SearchBar provider={provider} />
+      </MemoryRouter>
+    );
+    const input = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(input, { target: { value: 're' } });
+    await screen.findByText('Refurbished Laptop');
+    const items = screen.getAllByTestId('suggestion-item');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(items[0]).toHaveClass('bg-bg');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(items[1]).toHaveClass('bg-bg');
+  });
+
+  it('debounces and cancels stale requests', () => {
+    vi.useFakeTimers();
+    const provider: SuggestProvider = {
+      suggest: vi.fn().mockResolvedValue([]),
+    };
+    render(
+      <MemoryRouter>
+        <SearchBar provider={provider} />
+      </MemoryRouter>
+    );
+    const input = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(input, { target: { value: 'p' } });
+    fireEvent.change(input, { target: { value: 'pa' } });
+    vi.advanceTimersByTime(200);
+    expect(provider.suggest).toHaveBeenCalledTimes(1);
+    expect(provider.suggest).toHaveBeenCalledWith('pa', expect.any(AbortSignal));
+    vi.useRealTimers();
+  });
+
+  it('routes to results with type on selection', async () => {
+    const provider: SuggestProvider = {
+      suggest: vi.fn(async () => [
+        { id: '1', title: 'Refurbished Laptop', type: 'product' },
+      ]),
+    };
+    let loc: ReturnType<typeof useLocation>;
+    const Wrapper = ({ children }: { children: React.ReactNode }) => {
+      loc = useLocation();
+      return <>{children}</>;
+    };
+    render(
+      <MemoryRouter>
+        <Wrapper>
+          <SearchBar provider={provider} />
+        </Wrapper>
+      </MemoryRouter>
+    );
+    const input = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(input, { target: { value: 'ref' } });
+    await screen.findByText('Refurbished Laptop');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(loc!.pathname + loc!.search).toBe(
+      '/results?q=Refurbished%20Laptop&type=product'
+    );
+  });
+});

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -1,10 +1,12 @@
 import SearchBar from '../components/SearchBar';
+import LocalSeedProvider from '../suggest/LocalSeedProvider';
 
 // Landing page with centered SearchBar and themed background.
 export default function Search() {
+  const provider = new LocalSeedProvider();
   return (
     <div className="flex flex-col items-center justify-center py-24">
-      <SearchBar />
+      <SearchBar provider={provider} />
     </div>
   );
 }

--- a/ui/src/suggest/LocalSeedProvider.ts
+++ b/ui/src/suggest/LocalSeedProvider.ts
@@ -1,0 +1,30 @@
+import type { SuggestProvider, Suggestion } from './Provider';
+import dataset from './seed.json';
+
+/**
+ * LocalSeedProvider offers simple client-side suggestion lookup
+ * against a small static dataset. This keeps initial plumbing
+ * self-contained while allowing the SearchBar to swap providers
+ * later without code changes.
+ */
+export class LocalSeedProvider implements SuggestProvider {
+  async suggest(q: string, signal?: AbortSignal): Promise<Suggestion[]> {
+    const query = q.trim().toLowerCase();
+    if (!query) return [];
+
+    // Simulate async work so cancellation logic can be exercised.
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, 50);
+      signal?.addEventListener('abort', () => {
+        clearTimeout(timer);
+        reject(new DOMException('aborted', 'AbortError'));
+      });
+    });
+
+    return dataset.filter((item) =>
+      item.title.toLowerCase().includes(query)
+    );
+  }
+}
+
+export default LocalSeedProvider;

--- a/ui/src/suggest/Provider.ts
+++ b/ui/src/suggest/Provider.ts
@@ -1,0 +1,14 @@
+export interface Suggestion {
+  id: string;
+  title: string;
+  type: 'product' | 'company';
+}
+
+export interface SuggestProvider {
+  /**
+   * suggest returns possible completions for a query.
+   * Implementations should respect the AbortSignal to allow
+   * callers to cancel in-flight requests when queries change.
+   */
+  suggest(q: string, signal?: AbortSignal): Promise<Suggestion[]>;
+}

--- a/ui/src/suggest/seed.json
+++ b/ui/src/suggest/seed.json
@@ -1,0 +1,7 @@
+[
+  { "id": "c1", "title": "Patagonia", "type": "company" },
+  { "id": "c2", "title": "IKEA", "type": "company" },
+  { "id": "p1", "title": "Refurbished Laptop", "type": "product" },
+  { "id": "p2", "title": "Recycled Notebook", "type": "product" },
+  { "id": "p3", "title": "Organic Cotton T-Shirt", "type": "product" }
+]


### PR DESCRIPTION
## Summary
- add SuggestProvider interface with LocalSeedProvider seed
- make SearchBar suggestions pluggable with keyboard support
- add Storybook examples and tests for navigation and routing

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68bdda5ce9fc8321a7e6cccad17bee5f