### PR TITLE
feat(ui): add OFF mock product results

### DIFF
--- a/changelog/PR-UI-09-results-off-mock.md
+++ b/changelog/PR-UI-09-results-off-mock.md
@@ -1,0 +1,1 @@
+feat: add OFF mock product results grid

--- a/ui/src/adapters/offMock.ts
+++ b/ui/src/adapters/offMock.ts
@@ -1,0 +1,107 @@
+export interface OffMockItem {
+  id: string;
+  product_name: string;
+  brands: string;
+  image_url?: string;
+  ecoscore_grade?: 'a' | 'b' | 'c' | 'd' | 'e';
+  labels_tags?: string[];
+}
+
+const seed: OffMockItem[] = [
+  {
+    id: '1',
+    product_name: 'Organic Apple',
+    brands: 'Green Farms',
+    image_url: 'https://via.placeholder.com/150',
+    ecoscore_grade: 'a',
+    labels_tags: ['en:organic']
+  },
+  {
+    id: '2',
+    product_name: 'Chocolate Bar',
+    brands: 'Very Very Long Brand Name Incorporated',
+    ecoscore_grade: 'b'
+  },
+  {
+    id: '3',
+    product_name: 'Almond Milk',
+    brands: 'EcoMoo',
+    image_url: 'https://via.placeholder.com/150',
+    ecoscore_grade: 'c'
+  },
+  {
+    id: '4',
+    product_name: 'Instant Noodles',
+    brands: 'QuickEats',
+    image_url: 'https://via.placeholder.com/150',
+    ecoscore_grade: 'b'
+  },
+  {
+    id: '5',
+    product_name: 'Gluten-Free Bread',
+    brands: 'HealthyBites',
+    labels_tags: ['en:organic']
+  },
+  {
+    id: '6',
+    product_name: 'Tomato Ketchup',
+    brands: 'Local Harvest',
+    image_url: 'https://via.placeholder.com/150',
+    ecoscore_grade: 'a'
+  },
+  {
+    id: '7',
+    product_name: 'Canned Beans',
+    brands: 'BudgetFoods'
+  },
+  {
+    id: '8',
+    product_name: 'Olive Oil',
+    brands: 'Mediterranean Gold',
+    image_url: 'https://via.placeholder.com/150',
+    ecoscore_grade: 'c'
+  },
+  {
+    id: '9',
+    product_name: 'Energy Drink',
+    brands: 'GreenBoost',
+    image_url: 'https://via.placeholder.com/150',
+    ecoscore_grade: 'b'
+  },
+  {
+    id: '10',
+    product_name: 'Organic Yogurt',
+    brands: 'Farm Fresh',
+    image_url: 'https://via.placeholder.com/150',
+    ecoscore_grade: 'a',
+    labels_tags: ['en:organic']
+  },
+  {
+    id: '11',
+    product_name: 'Corn Flakes',
+    brands: 'MorningCo',
+    image_url: 'https://via.placeholder.com/150',
+    ecoscore_grade: 'b'
+  },
+  {
+    id: '12',
+    product_name: 'Vegan Sausage',
+    brands: 'Plantastic',
+    ecoscore_grade: 'c',
+    image_url: 'https://via.placeholder.com/150'
+  }
+];
+
+export async function searchOffMock(q: string): Promise<OffMockItem[]> {
+  const query = q.trim().toLowerCase();
+  if (!query) return [];
+  // simulate async latency
+  await new Promise((r) => setTimeout(r, 50));
+  return seed.filter(
+    (item) =>
+      item.product_name.toLowerCase().includes(query) ||
+      item.brands.toLowerCase().includes(query)
+  );
+}
+
+export default searchOffMock;

--- a/ui/src/components/CompanyCard.tsx
+++ b/ui/src/components/CompanyCard.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  name: string;
+}
+
+// CompanyCard is a simple placeholder for future company renderings.
+export default function CompanyCard({ name }: Props) {
+  return (
+    <div
+      data-testid="company-card"
+      className="rounded border border-soft-border bg-surface p-4"
+    >
+      <h3 className="font-semibold">{name}</h3>
+    </div>
+  );
+}

--- a/ui/src/components/ProductCard.stories.tsx
+++ b/ui/src/components/ProductCard.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ProductCard from './ProductCard';
+import type { Product } from '../mappers/offToProduct';
+
+const meta: Meta<typeof ProductCard> = {
+  title: 'Components/ProductCard',
+  component: ProductCard,
+};
+export default meta;
+
+const base: Product = {
+  id: '1',
+  title: 'Organic Apple',
+  brand: 'Green Farms',
+  image: 'https://via.placeholder.com/150',
+  badges: ['Eco-Score A', 'Organic'],
+  metrics: {},
+};
+
+export const WithImage: StoryObj<typeof ProductCard> = {
+  args: {
+    product: base,
+  },
+};
+
+export const MissingImage: StoryObj<typeof ProductCard> = {
+  args: {
+    product: { ...base, image: undefined, badges: ['Eco-Score C', 'Organic'] },
+  },
+};

--- a/ui/src/components/ProductCard.tsx
+++ b/ui/src/components/ProductCard.tsx
@@ -1,0 +1,46 @@
+import type { Product } from '../mappers/offToProduct';
+
+interface Props {
+  product: Product;
+}
+
+// ProductCard displays product info with badges and optional image.
+export default function ProductCard({ product }: Props) {
+  const { image, title, brand, badges } = product;
+  return (
+    <div
+      data-testid="product-card"
+      className="rounded border border-soft-border bg-surface p-4"
+    >
+      {image ? (
+        <img
+          src={image}
+          alt={title}
+          className="mb-2 h-40 w-full object-cover"
+        />
+      ) : (
+        <div
+          data-testid="image-placeholder"
+          className="mb-2 flex h-40 w-full items-center justify-center bg-bg text-sm text-gray-500"
+        >
+          No image
+        </div>
+      )}
+      <h3 className="font-semibold">{title}</h3>
+      <p className="text-sm text-gray-700">{brand}</p>
+      {badges.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {badges.map((b) => (
+            <span
+              key={b}
+              data-testid="badge"
+              className="rounded bg-bg px-2 py-0.5 text-xs text-gray-700"
+            >
+              {b}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/__tests__/ProductCard.test.tsx
+++ b/ui/src/components/__tests__/ProductCard.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import ProductCard from '../ProductCard';
+import type { Product } from '../../mappers/offToProduct';
+
+describe('ProductCard', () => {
+  const base: Product = {
+    id: '1',
+    title: 'Test Product',
+    brand: 'Brand',
+    image: 'https://via.placeholder.com/150',
+    badges: [],
+    metrics: {},
+  };
+
+  it('renders placeholder when image missing', () => {
+    render(<ProductCard product={{ ...base, image: undefined }} />);
+    expect(screen.getByTestId('image-placeholder')).toBeInTheDocument();
+  });
+
+  it('renders badges', () => {
+    render(<ProductCard product={{ ...base, badges: ['Eco-Score A', 'Organic'] }} />);
+    const badges = screen.getAllByTestId('badge');
+    expect(badges).toHaveLength(2);
+  });
+});

--- a/ui/src/mappers/__tests__/offToProduct.test.ts
+++ b/ui/src/mappers/__tests__/offToProduct.test.ts
@@ -1,0 +1,35 @@
+import { offToProduct } from '../offToProduct';
+import type { OffMockItem } from '../../adapters/offMock';
+
+describe('offToProduct', () => {
+  it('maps fields and badges correctly', () => {
+    const src: OffMockItem = {
+      id: '1',
+      product_name: 'Organic Apple',
+      brands: 'Green Farms',
+      image_url: 'img.jpg',
+      ecoscore_grade: 'a',
+      labels_tags: ['en:organic']
+    };
+    const res = offToProduct(src);
+    expect(res).toEqual({
+      id: '1',
+      title: 'Organic Apple',
+      brand: 'Green Farms',
+      image: 'img.jpg',
+      badges: ['Eco-Score A', 'Organic'],
+      metrics: {}
+    });
+  });
+
+  it('handles missing optional data', () => {
+    const src: OffMockItem = {
+      id: '2',
+      product_name: 'Plain Bread',
+      brands: 'Baker',
+    };
+    const res = offToProduct(src);
+    expect(res.image).toBeUndefined();
+    expect(res.badges).toHaveLength(0);
+  });
+});

--- a/ui/src/mappers/offToProduct.ts
+++ b/ui/src/mappers/offToProduct.ts
@@ -1,0 +1,34 @@
+import type { OffMockItem } from '../adapters/offMock';
+
+export interface Product {
+  id: string;
+  title: string;
+  brand: string;
+  image?: string;
+  badges: string[];
+  metrics: Record<string, unknown>;
+}
+
+/**
+ * offToProduct maps an OFF product to the UI's Product shape.
+ * It intentionally keeps transformation logic pure for easy testing.
+ */
+export function offToProduct(src: OffMockItem): Product {
+  const badges: string[] = [];
+  if (src.ecoscore_grade) {
+    badges.push(`Eco-Score ${src.ecoscore_grade.toUpperCase()}`);
+  }
+  if (src.labels_tags?.some((l) => l.includes('organic'))) {
+    badges.push('Organic');
+  }
+  return {
+    id: src.id,
+    title: src.product_name,
+    brand: src.brands,
+    image: src.image_url,
+    badges,
+    metrics: {},
+  };
+}
+
+export default offToProduct;

--- a/ui/src/pages/Results.tsx
+++ b/ui/src/pages/Results.tsx
@@ -1,17 +1,69 @@
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Search } from 'lucide-react';
 import EmptyState from '../components/EmptyState';
 import ErrorState from '../components/ErrorState';
 import ResultCard from '../components/ResultCard';
 import Skeleton from '../components/Skeleton';
+import ProductCard from '../components/ProductCard';
 import useMockSearch from '../hooks/useMockSearch';
+import searchOffMock from '../adapters/offMock';
+import { offToProduct, type Product } from '../mappers/offToProduct';
 
-// Results page reads query from URL and displays matching cards.
+// Results page reads query/type and displays matching cards.
 export default function Results() {
   const [params] = useSearchParams();
   const q = params.get('q') || '';
-  const { results, loading, error } = useMockSearch(q);
+  const type = params.get('type') || '';
 
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loadingProducts, setLoadingProducts] = useState(false);
+  const [errorProducts, setErrorProducts] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (type !== 'product') return;
+    if (!q) {
+      setProducts([]);
+      return;
+    }
+    setLoadingProducts(true);
+    searchOffMock(q)
+      .then((items) => {
+        setProducts(items.map(offToProduct));
+        setErrorProducts(null);
+      })
+      .catch((err) => setErrorProducts(err as Error))
+      .finally(() => setLoadingProducts(false));
+  }, [q, type]);
+
+  if (type === 'product') {
+    if (loadingProducts) return <Skeleton variant="cards" count={3} />;
+    if (errorProducts) return <ErrorState onRetry={() => location.reload()} />;
+    if (products.length === 0)
+      return (
+        <EmptyState
+          icon={<Search />}
+          title="No results"
+          description="Try a different search term."
+          action={<a href="/" className="text-primary underline">Go back</a>}
+        />
+      );
+    return (
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {products.map((p) => (
+          <ProductCard key={p.id} product={p} />
+        ))}
+        <button
+          className="col-span-full rounded border border-soft-border px-4 py-2 text-sm text-gray-700"
+          disabled
+        >
+          Load more
+        </button>
+      </div>
+    );
+  }
+
+  const { results, loading, error } = useMockSearch(q);
   if (loading) return <Skeleton variant="cards" count={3} />;
   if (error) return <ErrorState onRetry={() => location.reload()} />;
   if (results.length === 0)
@@ -23,7 +75,6 @@ export default function Results() {
         action={<a href="/" className="text-primary underline">Go back</a>}
       />
     );
-
   return (
     <div>
       {results.map((item) => (


### PR DESCRIPTION
## Summary
- mock Open Food Facts adapter seeds diverse products
- map OFF items to Product cards
- render product grid on results page with placeholders

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde18b36a08321afc986ee46c65d39