### PR TITLE
chore(ci): compile changelog safely (paths-ignore, permissions, prepend history)

### DIFF
--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -1,30 +1,34 @@
 name: release-compile-changelog
-
 on:
   push:
-    branches: [main]
-
+    branches: [ main ]
+    # Avoid re-triggering on the bot's own compile commit
+    paths-ignore:
+      - 'PROJECT_CHANGELOG.md'
+permissions:
+  contents: write
+concurrency:
+  group: changelog-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   compile:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        with: { fetch-depth: 0 }
       - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Build changelog
-        run: python scripts/build_changelog.py
-      - name: Commit and push
+      - name: Compile changelog
         run: |
           set -euo pipefail
-          if git diff --quiet; then
-            echo 'No fragments to compile'
-            exit 0
+          python3 scripts/build_changelog.py --fragments changelog --out PROJECT_CHANGELOG.md
+      - name: Commit changelog if changed
+        run: |
+          if ! git diff --quiet PROJECT_CHANGELOG.md; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add PROJECT_CHANGELOG.md
+            git commit -m "chore(changelog): compile fragments [skip ci]"
+            git push
+          else
+            echo "No changes to PROJECT_CHANGELOG.md"
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add PROJECT_CHANGELOG.md changelog || true
-          git commit -m "chore(changelog): compile fragments"
-          git push

--- a/changelog/CI-CHLOG-02-compiler-fixes.md
+++ b/changelog/CI-CHLOG-02-compiler-fixes.md
@@ -1,0 +1,1 @@
+CI: Safe compiler; preserves history; no loop.

--- a/scripts/build_changelog.py
+++ b/scripts/build_changelog.py
@@ -1,40 +1,55 @@
 #!/usr/bin/env python3
 """Compile changelog fragments into PROJECT_CHANGELOG.md.
 
-Why: avoid merge conflicts by keeping one fragment per PR that is stitched
-into the project changelog automatically on merge."""
+Why: keep a single canonical changelog that is automatically generated on
+merge while preserving existing history. This script prepends today's
+fragments to the existing log without touching prior sections."""
 
-from __future__ import annotations
-
-import datetime as _dt
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parent.parent
-FRAGMENTS_DIR = ROOT / "changelog"
-OUTPUT_FILE = ROOT / "PROJECT_CHANGELOG.md"
+import argparse
+import datetime
+import glob
+import os
+import io
 
 
-def main() -> int:
-    """Build the changelog and remove processed fragments."""
-    fragments = sorted(
-        p for p in FRAGMENTS_DIR.glob("*.md") if p.name not in {"README.md", "0000-example.md"}
-    )
-    if not fragments:
-        # Nothing to do; keep existing changelog untouched.
-        return 0
+def main() -> None:
+    """Build the changelog from fragments and preserve prior entries."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fragments", default="changelog")
+    parser.add_argument("--out", default="PROJECT_CHANGELOG.md")
+    args = parser.parse_args()
 
-    today = _dt.date.today().isoformat()
-    lines = ["# PROJECT_CHANGELOG", "", f"## {today}", ""]
-    for frag in fragments:
-        lines.append(frag.read_text().strip())
-        lines.append("")  # blank line between entries
-    OUTPUT_FILE.write_text("\n".join(lines).rstrip() + "\n")
+    today = datetime.date.today().isoformat()
+    frags = sorted(glob.glob(os.path.join(args.fragments, "*.md")))
+    if not frags:
+        # Nothing to compile; exiting keeps history untouched.
+        raise SystemExit(0)
 
-    # Remove fragments after compiling so they aren't re-used.
-    for frag in fragments:
-        frag.unlink()
-    return 0
+    # Read existing changelog content if present.
+    previous = ""
+    if os.path.exists(args.out):
+        with open(args.out, "r", encoding="utf-8") as fh:
+            previous = fh.read().strip()
+
+    # Normalise the header so we can safely prepend a new section.
+    header = "# PROJECT_CHANGELOG"
+    if previous.startswith(header):
+        previous = previous[len(header):].lstrip()
+
+    buf = io.StringIO()
+    buf.write(header + "\n\n")
+    buf.write(f"## {today}\n\n")
+    for frag in frags:
+        with open(frag, "r", encoding="utf-8") as fh:
+            buf.write(fh.read().strip() + "\n\n")
+
+    # Append prior changelog content (if any) to preserve history.
+    if previous:
+        buf.write(previous.strip() + "\n")
+
+    with open(args.out, "w", encoding="utf-8") as out_fh:
+        out_fh.write(buf.getvalue())
 
 
 if __name__ == "__main__":  # pragma: no cover - script entry point
-    raise SystemExit(main())
+    main()


### PR DESCRIPTION
## Summary
- guard changelog compilation from loops and concurrent runs
- prepend new entries atop existing changelog preserving history
- record fragment for compiler workflow fixes

## Testing
- `pre-commit run --files scripts/build_changelog.py .github/workflows/release-compile-changelog.yml changelog/CI-CHLOG-02-compiler-fixes.md` *(fails: `.pre-commit-config.yaml is not a file`)*
- `pytest`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68bde1d89b40832199ebd296411e45ed