### PR TITLE
feat(web): add preview auth middleware

### DIFF
--- a/.github/workflows/vercel-preview-note.yml
+++ b/.github/workflows/vercel-preview-note.yml
@@ -1,0 +1,9 @@
+name: PR – Vercel Preview Note
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  note:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Vercel will comment a private Preview URL once the first build finishes (protected by Vercel Authentication)."

--- a/apps/web/README.vercel.md
+++ b/apps/web/README.vercel.md
@@ -1,0 +1,26 @@
+# Vercel deployment
+
+Framework: Next.js
+Root Directory (Vercel): apps/web
+Install Command: pnpm install
+Build Command: pnpm build
+Output:
+
+Security:
+- Enable "Vercel Authentication" → Standard Protection (Preview Deployments).
+- Team members only (keep team = just the owner).
+- Disable shareable links.
+- Optional fallback: set PREVIEW_AUTH_USER and PREVIEW_AUTH_PASS for Preview environment to activate middleware.
+
+Faster builds (optional) — Ignored Build Step:
+```
+CHANGED=$(git diff --name-only "$VERCEL_GIT_PREVIOUS_SHA..$VERCEL_GIT_COMMIT_SHA" 2>/dev/null || true)
+echo "$CHANGED" | egrep -q '^(apps/web/|packages/ui/|packages/utils/|packages/schemas/)' && exit 1 || { echo "Skip apps/web"; exit 0; }
+```
+
+One-time Vercel env for the middleware (only if you enable it):
+
+PREVIEW_AUTH_USER = <your_username>
+PREVIEW_AUTH_PASS = <your_password>
+
+Leave them unset in Production so live site stays public.

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// Preview-only Basic Auth middleware
+// Why: guard non-production deployments when preview credentials are set
+const isProd = process.env.VERCEL_ENV === 'production';
+
+export function middleware(req: NextRequest) {
+  // Skip in production to avoid affecting live traffic
+  if (isProd) return NextResponse.next();
+
+  const user = process.env.PREVIEW_AUTH_USER || '';
+  const pass = process.env.PREVIEW_AUTH_PASS || '';
+  // If credentials are missing, bypass auth to avoid accidental lockouts
+  if (!user || !pass) return NextResponse.next();
+
+  const header = req.headers.get('authorization') || '';
+  const [scheme, encoded] = header.split(' ');
+  if (scheme !== 'Basic' || !encoded) {
+    // Prompt for credentials when auth header absent or malformed
+    return new NextResponse('Authentication required', {
+      status: 401,
+      headers: { 'WWW-Authenticate': 'Basic realm="Preview"' },
+    });
+  }
+
+  const [u, p] = Buffer.from(encoded, 'base64').toString().split(':');
+  // Allow only when provided credentials match preview env values
+  if (u === user && p === pass) return NextResponse.next();
+
+  return new NextResponse('Forbidden', { status: 403 });
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};

--- a/changelog/preview-auth-middleware.md
+++ b/changelog/preview-auth-middleware.md
@@ -1,0 +1,1 @@
+feat: add preview-only auth middleware for web app


### PR DESCRIPTION
## Summary
- add preview-only basic auth middleware for Next.js app
- document Vercel configuration and security
- note workflow informing about Vercel preview URLs

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdeaea25188321af26493d7e734659