### PR TITLE
feat(connectors): add Library of Things UK connector

### DIFF
--- a/changelog.d/feat-connector-libraryofthings-uk.md
+++ b/changelog.d/feat-connector-libraryofthings-uk.md
@@ -1,0 +1,1 @@
+feat(connectors): add isolated Library of Things (UK) connector with myTurn provider (opt-in live) and fixture stubs for LoT platform & Lend Engine; includes CLI, tests, docs

--- a/connectors/libraryofthings_uk/README.md
+++ b/connectors/libraryofthings_uk/README.md
@@ -1,0 +1,13 @@
+# Library of Things UK Connector
+
+This module houses an isolated connector for UK "Library of Things" style
+catalogues. It intentionally ships without external dependencies and mirrors the
+patterns used by other connectors in this repo.
+
+Providers:
+
+- **myTurn** – real provider with optional live HTTP (requires `MYTURN_BASE_URL`).
+- **lot** – stub for the Library of Things platform using fixtures.
+- **lendengine** – stub for Lend Engine deployments using fixtures.
+
+See the `docs/connectors/libraryofthings_uk.md` page for details and CLI usage.

--- a/connectors/libraryofthings_uk/__init__.py
+++ b/connectors/libraryofthings_uk/__init__.py
@@ -1,0 +1,1 @@
+"""Library of Things UK connector package."""

--- a/connectors/libraryofthings_uk/adapter.py
+++ b/connectors/libraryofthings_uk/adapter.py
@@ -1,0 +1,88 @@
+"""Normalize Library of Things (UK) provider payloads to ``UniversalBorrowV0``.
+
+The connector is intentionally lightweight and defensive so each provider can
+map its responses without coupling to global schemas. Only a small subset of
+data is captured for provenance and demonstration purposes.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from typing import Dict, List, Optional, TypedDict
+
+
+class Price(TypedDict, total=False):
+    value: Optional[float]
+    currency: Optional[str]
+    per: Optional[str]
+
+
+class Availability(TypedDict, total=False):
+    status: Optional[str]
+    nextAvailable: Optional[str]
+    calendarUrl: Optional[str]
+
+
+class Location(TypedDict, total=False):
+    name: Optional[str]
+    address: Optional[str]
+    postcode: Optional[str]
+    city: Optional[str]
+    lat: Optional[float]
+    lon: Optional[float]
+
+
+class UniversalBorrowV0(TypedDict, total=False):
+    source: str
+    provider: str
+    id: str
+    title: Optional[str]
+    category: Optional[str]
+    images: List[str]
+    url: Optional[str]
+    price: Price
+    deposit: Price
+    availability: Availability
+    location: Location
+    badges: List[str]
+    provenance: Dict
+
+
+def iso_now() -> str:
+    """Return the current UTC timestamp in ISO8601."""
+
+    return _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def sanitize_raw(raw: Dict, max_bytes: int = 30000) -> Dict:
+    """Trim large values so provenance stays reasonably small.
+
+    The function recursively truncates long strings and lists. If the resulting
+    JSON blob still exceeds ``max_bytes`` the dict is pruned key by key until the
+    size fits. This keeps provenance from ballooning in tests or fixtures.
+    """
+
+    def _trim(val):
+        if isinstance(val, list):
+            return [_trim(v) for v in val[:20]]
+        if isinstance(val, dict):
+            return {k: _trim(v) for k, v in list(val.items())[:20]}
+        if isinstance(val, str) and len(val) > 1000:
+            return val[:1000]
+        return val
+
+    sanitized = _trim(raw)
+    encoded = json.dumps(sanitized, ensure_ascii=False).encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return sanitized
+
+    # Drop trailing keys until under the byte budget. The exact keys are not
+    # important for provenance; keeping something is better than nothing.
+    pruned: Dict = {}
+    for key, value in sanitized.items():
+        tentative = {**pruned, key: value}
+        if len(json.dumps(tentative, ensure_ascii=False).encode("utf-8")) > max_bytes:
+            break
+        pruned = tentative
+    return pruned

--- a/connectors/libraryofthings_uk/cli.py
+++ b/connectors/libraryofthings_uk/cli.py
@@ -1,0 +1,70 @@
+"""JSON Lines CLI for the Library of Things (UK) connector.
+
+The CLI is intentionally tiny and dependency-free. It prints each normalized
+item as a JSON object per line so results can be piped or inspected manually.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import List
+
+from . import client
+from .providers import myturn
+
+
+def _print(items: List[dict]) -> None:
+    for item in items:
+        print(json.dumps(item, ensure_ascii=False))
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Library of Things UK connector CLI"
+    )
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_search = sub.add_parser("search", help="search for items")
+    p_search.add_argument("--provider", required=True, choices=["myturn", "lendengine", "lot"])
+    p_search.add_argument("--q", required=True)
+    p_search.add_argument("--limit", type=int, default=5)
+    p_search.add_argument("--offset", type=int, default=0)
+    p_search.add_argument("--category")
+
+    p_item = sub.add_parser("item", help="fetch a single item")
+    p_item.add_argument("--provider", required=True, choices=["myturn", "lendengine", "lot"])
+    p_item.add_argument("--id", required=True)
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.cmd == "search":
+            items = client.search_items(
+                args.provider,
+                args.q,
+                limit=args.limit,
+                offset=args.offset,
+                category=args.category,
+            )
+            _print(items)
+        elif args.cmd == "item":
+            item = client.get_item(args.provider, args.id)
+            if item:
+                _print([item])
+        else:
+            parser.print_help()
+            return 1
+    except (
+        client.ProviderNotAvailableError,
+        myturn.MyTurnHttpError,
+        myturn.MyTurnParseError,
+    ) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/connectors/libraryofthings_uk/client.py
+++ b/connectors/libraryofthings_uk/client.py
@@ -1,0 +1,50 @@
+"""Provider dispatcher for Library of Things (UK) connectors.
+
+A thin wrapper that routes calls to the appropriate provider module. Keeping the
+logic here avoids leaking provider-specific behaviour to callers and makes the
+connector pluggable.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from .adapter import UniversalBorrowV0
+from .providers import lendengine_stub, lot_stub, myturn
+
+__all__ = ["ProviderNotAvailableError", "search_items", "get_item"]
+
+
+class ProviderNotAvailableError(Exception):
+    """Raised when a requested provider is not implemented."""
+
+
+_PROVIDERS = {
+    "myturn": myturn,
+    "lendengine": lendengine_stub,
+    "lot": lot_stub,
+}
+
+
+def search_items(
+    provider: str,
+    query: str,
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs,
+) -> List[UniversalBorrowV0]:
+    """Dispatch to ``provider.search_items`` and return normalized items."""
+
+    if provider not in _PROVIDERS:
+        raise ProviderNotAvailableError(provider)
+    mod = _PROVIDERS[provider]
+    return mod.search_items(query, limit=limit, offset=offset, **kwargs)
+
+
+def get_item(provider: str, item_id: str, **kwargs) -> UniversalBorrowV0 | None:
+    """Dispatch to ``provider.get_item`` and return a normalized item."""
+
+    if provider not in _PROVIDERS:
+        raise ProviderNotAvailableError(provider)
+    mod = _PROVIDERS[provider]
+    return mod.get_item(item_id, **kwargs)

--- a/connectors/libraryofthings_uk/fixtures/lendengine_stub_inventory.json
+++ b/connectors/libraryofthings_uk/fixtures/lendengine_stub_inventory.json
@@ -1,0 +1,43 @@
+{
+  "items": [
+    {
+      "id": "le1",
+      "title": "Cordless Drill",
+      "category": "Tools",
+      "image": "https://example.org/le-drill.jpg",
+      "url": "https://lend-engine.com/items/le1",
+      "price": 4.0,
+      "deposit": 20.0,
+      "status": "available",
+      "nextAvailable": "2023-08-15",
+      "location": "Leith",
+      "postcode": "EH6 6QQ"
+    },
+    {
+      "id": "le2",
+      "title": "Jigsaw",
+      "category": "Tools",
+      "image": "https://example.org/le-jigsaw.jpg",
+      "url": "https://lend-engine.com/items/le2",
+      "price": 5.0,
+      "deposit": 25.0,
+      "status": "available",
+      "nextAvailable": "2023-08-18",
+      "location": "New Town",
+      "postcode": "EH2 3JD"
+    },
+    {
+      "id": "le3",
+      "title": "Angle Grinder",
+      "category": "Tools",
+      "image": "https://example.org/le-grinder.jpg",
+      "url": "https://lend-engine.com/items/le3",
+      "price": 6.0,
+      "deposit": 30.0,
+      "status": "unavailable",
+      "nextAvailable": "2023-08-30",
+      "location": "Gorgie",
+      "postcode": "EH11 2QT"
+    }
+  ]
+}

--- a/connectors/libraryofthings_uk/fixtures/lot_stub_inventory.json
+++ b/connectors/libraryofthings_uk/fixtures/lot_stub_inventory.json
@@ -1,0 +1,43 @@
+{
+  "items": [
+    {
+      "id": "lot1",
+      "title": "Sewing Machine",
+      "category": "Craft",
+      "image": "https://example.org/sewing.jpg",
+      "url": "https://libraryofthings.co.uk/items/lot1",
+      "price": 8.0,
+      "deposit": 40.0,
+      "status": "available",
+      "nextAvailable": "2023-08-20",
+      "location": "Camden",
+      "postcode": "NW1 0NE"
+    },
+    {
+      "id": "lot2",
+      "title": "Pressure Washer",
+      "category": "Garden",
+      "image": "https://example.org/washer.jpg",
+      "url": "https://libraryofthings.co.uk/items/lot2",
+      "price": 12.0,
+      "deposit": 50.0,
+      "status": "available",
+      "nextAvailable": "2023-08-25",
+      "location": "Brixton",
+      "postcode": "SW9 8HB"
+    },
+    {
+      "id": "lot3",
+      "title": "Dehumidifier",
+      "category": "Home",
+      "image": "https://example.org/dehumidifier.jpg",
+      "url": "https://libraryofthings.co.uk/items/lot3",
+      "price": 10.0,
+      "deposit": 45.0,
+      "status": "unavailable",
+      "nextAvailable": "2023-09-05",
+      "location": "Walthamstow",
+      "postcode": "E17 7LP"
+    }
+  ]
+}

--- a/connectors/libraryofthings_uk/fixtures/myturn_item.json
+++ b/connectors/libraryofthings_uk/fixtures/myturn_item.json
@@ -1,0 +1,14 @@
+{
+  "_source_url": "fixture://myturn_item",
+  "id": "mt1",
+  "name": "Hammer Drill",
+  "category": "Tools",
+  "photo": "https://example.org/hammerdrill.jpg",
+  "itemUrl": "https://edinburgh.myturn.com/library/viewitem.html?item_id=mt1",
+  "dailyCharge": 7.5,
+  "deposit": 30.0,
+  "status": "available",
+  "nextAvailable": "2023-09-10",
+  "branch": "Central Library",
+  "postcode": "EH1 1AA"
+}

--- a/connectors/libraryofthings_uk/fixtures/myturn_search.json
+++ b/connectors/libraryofthings_uk/fixtures/myturn_search.json
@@ -1,0 +1,31 @@
+{
+  "_source_url": "fixture://myturn_search",
+  "results": [
+    {
+      "id": "mt1",
+      "name": "Hammer Drill",
+      "category": "Tools",
+      "photo": "https://example.org/hammerdrill.jpg",
+      "itemUrl": "https://edinburgh.myturn.com/library/viewitem.html?item_id=mt1",
+      "dailyCharge": 7.5,
+      "deposit": 30.0,
+      "status": "available",
+      "nextAvailable": "2023-09-10",
+      "branch": "Central Library",
+      "postcode": "EH1 1AA"
+    },
+    {
+      "id": "mt2",
+      "name": "Sander",
+      "category": "Tools",
+      "photo": "https://example.org/sander.jpg",
+      "itemUrl": "https://edinburgh.myturn.com/library/viewitem.html?item_id=mt2",
+      "dailyCharge": 5.0,
+      "deposit": 15.0,
+      "status": "unavailable",
+      "nextAvailable": "2023-09-15",
+      "branch": "West Branch",
+      "postcode": "EH2 2BB"
+    }
+  ]
+}

--- a/connectors/libraryofthings_uk/providers/__init__.py
+++ b/connectors/libraryofthings_uk/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Provider implementations for the Library of Things UK connector."""

--- a/connectors/libraryofthings_uk/providers/lendengine_stub.py
+++ b/connectors/libraryofthings_uk/providers/lendengine_stub.py
@@ -1,0 +1,69 @@
+"""Fixture-backed stub for Lend Engine deployments.
+
+Many UK libraries use Lend Engine but public API details are scarce. This stub
+models a tiny inventory using static fixtures until official endpoints are
+available.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ..adapter import Availability, Location, Price, UniversalBorrowV0, iso_now, sanitize_raw
+
+_FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "lendengine_stub_inventory.json"
+
+
+def _load() -> List[Dict]:
+    with open(_FIXTURE, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("items", [])
+
+
+def _map(item: Dict) -> UniversalBorrowV0:
+    images = [item["image"]] if item.get("image") else []
+    price: Price = {"value": float(item.get("price", 0)), "currency": "GBP", "per": "day"}
+    deposit: Price = {"value": float(item.get("deposit", 0)), "currency": "GBP"}
+    availability: Availability = {
+        "status": item.get("status"),
+        "nextAvailable": item.get("nextAvailable"),
+    }
+    location: Location = {
+        "name": item.get("location"),
+        "postcode": item.get("postcode"),
+    }
+    return {
+        "source": "lot-uk:lendengine",
+        "provider": "lendengine",
+        "id": str(item.get("id")),
+        "title": item.get("title"),
+        "category": item.get("category"),
+        "images": images,
+        "url": item.get("url"),
+        "price": price,
+        "deposit": deposit,
+        "availability": availability,
+        "location": location,
+        "badges": item.get("badges", []),
+        "provenance": {
+            "source_url": "fixture://lendengine_stub_inventory",
+            "fetched_at": iso_now(),
+            "raw": sanitize_raw(item),
+        },
+    }
+
+
+def search_items(query: str, limit: int = 20, offset: int = 0, **_: dict) -> List[UniversalBorrowV0]:
+    items = _load()
+    filtered = [i for i in items if query.lower() in i.get("title", "").lower()]
+    sliced = filtered[offset : offset + limit]
+    return [_map(i) for i in sliced]
+
+
+def get_item(item_id: str, **_: dict) -> Optional[UniversalBorrowV0]:
+    for item in _load():
+        if str(item.get("id")) == str(item_id):
+            return _map(item)
+    return None

--- a/connectors/libraryofthings_uk/providers/lot_stub.py
+++ b/connectors/libraryofthings_uk/providers/lot_stub.py
@@ -1,0 +1,69 @@
+"""Fixture-backed stub for the Library of Things UK platform.
+
+This stub demonstrates the connector shape without relying on the real
+Library of Things platform which currently lacks an open API. It reads from a
+small JSON fixture bundled with the repo.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ..adapter import Availability, Location, Price, UniversalBorrowV0, iso_now, sanitize_raw
+
+_FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "lot_stub_inventory.json"
+
+
+def _load() -> List[Dict]:
+    with open(_FIXTURE, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("items", [])
+
+
+def _map(item: Dict) -> UniversalBorrowV0:
+    images = [item["image"]] if item.get("image") else []
+    price: Price = {"value": float(item.get("price", 0)), "currency": "GBP", "per": "day"}
+    deposit: Price = {"value": float(item.get("deposit", 0)), "currency": "GBP"}
+    availability: Availability = {
+        "status": item.get("status"),
+        "nextAvailable": item.get("nextAvailable"),
+    }
+    location: Location = {
+        "name": item.get("location"),
+        "postcode": item.get("postcode"),
+    }
+    return {
+        "source": "lot-uk:platform",
+        "provider": "lot",
+        "id": str(item.get("id")),
+        "title": item.get("title"),
+        "category": item.get("category"),
+        "images": images,
+        "url": item.get("url"),
+        "price": price,
+        "deposit": deposit,
+        "availability": availability,
+        "location": location,
+        "badges": item.get("badges", []),
+        "provenance": {
+            "source_url": "fixture://lot_stub_inventory",
+            "fetched_at": iso_now(),
+            "raw": sanitize_raw(item),
+        },
+    }
+
+
+def search_items(query: str, limit: int = 20, offset: int = 0, **_: dict) -> List[UniversalBorrowV0]:
+    items = _load()
+    filtered = [i for i in items if query.lower() in i.get("title", "").lower()]
+    sliced = filtered[offset : offset + limit]
+    return [_map(i) for i in sliced]
+
+
+def get_item(item_id: str, **_: dict) -> Optional[UniversalBorrowV0]:
+    for item in _load():
+        if str(item.get("id")) == str(item_id):
+            return _map(item)
+    return None

--- a/connectors/libraryofthings_uk/providers/myturn.py
+++ b/connectors/libraryofthings_uk/providers/myturn.py
@@ -1,0 +1,212 @@
+"""myTurn provider for Library of Things (UK).
+
+Uses fixtures by default and only performs live HTTP when ``MYTURN_BASE_URL`` is
+configured. This keeps tests deterministic while allowing maintainers with API
+access to opt in to live requests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ..adapter import (
+    Availability,
+    Location,
+    Price,
+    UniversalBorrowV0,
+    iso_now,
+    sanitize_raw,
+)
+
+__all__ = ["MyTurnHttpError", "MyTurnParseError", "search_items", "get_item"]
+
+USER_AGENT = "circl-lot-myturn/0.1 (+https://github.com/andremair97/circl-docs)"
+
+
+class MyTurnHttpError(Exception):
+    """Raised when the myTurn endpoint cannot be reached or returns an error."""
+
+
+class MyTurnParseError(Exception):
+    """Raised when a myTurn response cannot be parsed as JSON."""
+
+
+_tokens: float = 0.0
+_last: float = time.monotonic()
+
+
+def _throttle() -> None:
+    """Naive token bucket so we do not overwhelm small deployments."""
+
+    global _tokens, _last
+    rate = float(os.getenv("MYTURN_REQUESTS_PER_SEC", "4"))
+    capacity = max(rate, 1)
+    now = time.monotonic()
+    elapsed = now - _last
+    _tokens = min(capacity, _tokens + elapsed * rate)
+    if _tokens < 1:
+        wait = (1 - _tokens) / rate
+        time.sleep(wait + random.uniform(0, 0.1))
+        now = time.monotonic()
+        elapsed = now - _last
+        _tokens = min(capacity, _tokens + elapsed * rate)
+    _tokens -= 1
+    _last = now
+
+
+def _request(url: str) -> Dict:
+    """Perform a GET request and return JSON payload."""
+
+    _throttle()
+    headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+    token = os.getenv("MYTURN_API_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    timeout = float(os.getenv("MYTURN_TIMEOUT_SECONDS", "10"))
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = getattr(resp, "status", resp.getcode())
+            if status != 200:
+                raise MyTurnHttpError(f"HTTP {status} for {url}")
+            raw = resp.read()
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure
+        raise MyTurnHttpError(str(exc)) from exc
+
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise MyTurnParseError(str(exc)) from exc
+    data["_source_url"] = url
+    return data
+
+
+def _fixture_path(name: str) -> Path:
+    return Path(__file__).resolve().parent.parent / "fixtures" / name
+
+
+def _map_item(raw: Dict, source_url: str) -> UniversalBorrowV0:
+    images: List[str] = []
+    photo = raw.get("photo") or raw.get("image")
+    if isinstance(photo, str):
+        images.append(photo)
+
+    price: Price = {}
+    daily = raw.get("dailyCharge") or raw.get("price")
+    if daily is not None:
+        try:
+            price["value"] = float(daily)
+        except (TypeError, ValueError):
+            pass
+        price["currency"] = "GBP"
+        price["per"] = "day"
+
+    deposit: Price = {}
+    dep = raw.get("deposit") or raw.get("depositAmount")
+    if dep is not None:
+        try:
+            deposit["value"] = float(dep)
+        except (TypeError, ValueError):
+            pass
+        deposit["currency"] = "GBP"
+
+    availability: Availability = {}
+    status = raw.get("status") or raw.get("availability")
+    if status:
+        availability["status"] = str(status)
+    nxt = raw.get("nextAvailable") or raw.get("next")
+    if nxt:
+        availability["nextAvailable"] = str(nxt)
+
+    location: Location = {}
+    branch = raw.get("branch") or raw.get("location")
+    if branch:
+        location["name"] = branch
+    postcode = raw.get("postcode") or raw.get("postal")
+    if postcode:
+        location["postcode"] = postcode
+
+    url = raw.get("itemUrl") or raw.get("url")
+
+    return {
+        "source": "lot-uk:myturn",
+        "provider": "myturn",
+        "id": str(raw.get("id")),
+        "title": raw.get("name"),
+        "category": raw.get("category"),
+        "images": images,
+        "url": url,
+        "price": price,
+        "deposit": deposit,
+        "availability": availability,
+        "location": location,
+        "badges": [],
+        "provenance": {
+            "source_url": source_url,
+            "fetched_at": iso_now(),
+            "raw": sanitize_raw(raw),
+        },
+    }
+
+
+def search_items(
+    query: str,
+    limit: int = 20,
+    offset: int = 0,
+    category: Optional[str] = None,
+    use_fixture: bool = False,
+) -> List[UniversalBorrowV0]:
+    """Search items via myTurn.
+
+    When ``use_fixture`` is True or ``MYTURN_BASE_URL`` is unset the function
+    reads from bundled fixtures. Otherwise it attempts a live HTTP call to a
+    tenant's self-service API.
+    """
+
+    if use_fixture or not os.getenv("MYTURN_BASE_URL"):
+        path = _fixture_path("myturn_search.json")
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    else:
+        base = os.getenv("MYTURN_BASE_URL")
+        assert base  # for type checkers
+        encoded = urllib.parse.quote(query.strip())
+        url = f"{base.rstrip('/')}/api/search/items?q={encoded}&limit={limit}&offset={offset}"
+        if category:
+            url += f"&category={urllib.parse.quote(category)}"
+        data = _request(url)
+
+    source_url = data.get("_source_url", "")
+    results = data.get("results") or data.get("items") or []
+    if use_fixture or not os.getenv("MYTURN_BASE_URL"):
+        filtered = [r for r in results if query.lower() in str(r.get("name", "")).lower()]
+    else:
+        filtered = results
+    sliced = filtered[offset : offset + limit]
+    return [_map_item(r, source_url) for r in sliced]
+
+
+def get_item(item_id: str, use_fixture: bool = False) -> Optional[UniversalBorrowV0]:
+    """Fetch a single item by ``item_id``."""
+
+    if use_fixture or not os.getenv("MYTURN_BASE_URL"):
+        path = _fixture_path("myturn_item.json")
+        with open(path, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+    else:
+        base = os.getenv("MYTURN_BASE_URL")
+        if not base:
+            raise MyTurnHttpError("MYTURN_BASE_URL not set; cannot fetch item")
+        url = f"{base.rstrip('/')}/api/items/{urllib.parse.quote(item_id)}"
+        raw = _request(url)
+
+    source_url = raw.get("_source_url", "")
+    return _map_item(raw, source_url)

--- a/docs/connectors/libraryofthings_uk.md
+++ b/docs/connectors/libraryofthings_uk.md
@@ -1,0 +1,58 @@
+# Library of Things (UK) connector
+
+The Library of Things connector surfaces borrowable items from UK tool and
+thing libraries. It is self‑contained and does not hook into the global UI or
+schemas yet.
+
+## Providers
+
+- `myturn` – supports live HTTP when `MYTURN_BASE_URL` is set and optionally
+  `MYTURN_API_TOKEN`. Without those variables the provider falls back to bundled
+  fixtures.
+- `lot` – stub for the Library of Things platform. Fixture only.
+- `lendengine` – stub for Lend Engine deployments. Fixture only.
+
+## Environment
+
+- `MYTURN_BASE_URL` – tenant base URL such as `https://edinburgh.myturn.com`.
+- `MYTURN_API_TOKEN` – optional bearer or token header.
+- `MYTURN_TIMEOUT_SECONDS` – request timeout (default 10).
+- `MYTURN_REQUESTS_PER_SEC` – polite rate limit (default 4).
+
+## CLI
+
+Search for an item:
+
+```bash
+python -m connectors.libraryofthings_uk.cli search --provider myturn --q "drill"
+```
+
+Fetch a single item:
+
+```bash
+python -m connectors.libraryofthings_uk.cli item --provider myturn --id "mt1"
+```
+
+## Normalized output
+
+Each provider returns items shaped as `UniversalBorrowV0`:
+
+```json
+{
+  "source": "lot-uk:myturn",
+  "provider": "myturn",
+  "id": "mt1",
+  "title": "Hammer Drill",
+  "price": {"value": 7.5, "currency": "GBP", "per": "day"},
+  "deposit": {"value": 30.0, "currency": "GBP"},
+  "availability": {"status": "available"},
+  "location": {"name": "Central Library", "postcode": "EH1 1AA"},
+  "provenance": {"source_url": "…", "fetched_at": "2023-08-01T00:00:00Z"}
+}
+```
+
+## Notes
+
+- Fixtures keep unit tests offline and tiny. Opt into live tests by setting
+  `LOT_LIVE_TEST=1` and `MYTURN_BASE_URL`.
+- Requests include a custom User‑Agent and basic throttling for politeness.

--- a/tests/connectors/test_libraryofthings_uk_live_myturn.py
+++ b/tests/connectors/test_libraryofthings_uk_live_myturn.py
@@ -1,0 +1,20 @@
+import os
+
+import pytest
+
+from connectors.libraryofthings_uk import client
+
+if not (os.getenv("LOT_LIVE_TEST") == "1" and os.getenv("MYTURN_BASE_URL")):
+    pytest.skip(
+        "Live myTurn test skipped (set LOT_LIVE_TEST=1 and MYTURN_BASE_URL)",
+        allow_module_level=True,
+    )
+
+
+def test_live_search_and_get():
+    results = client.search_items("myturn", "drill", limit=2)
+    assert results
+    first = results[0]
+    assert first.get("id") and first.get("title") and first.get("url")
+    item = client.get_item("myturn", first["id"])
+    assert item and item["id"] == first["id"]

--- a/tests/connectors/test_libraryofthings_uk_unit.py
+++ b/tests/connectors/test_libraryofthings_uk_unit.py
@@ -1,0 +1,50 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from connectors.libraryofthings_uk import adapter, client
+from connectors.libraryofthings_uk.providers import lendengine_stub, lot_stub
+
+FIXTURES = Path(__file__).resolve().parents[2] / "connectors" / "libraryofthings_uk" / "fixtures"
+
+
+def _required_keys(item):
+    for key in ["source", "provider", "id", "title", "price", "location", "provenance"]:
+        assert key in item
+
+
+def test_lot_stub_search_and_get():
+    items = lot_stub.search_items("Sewing")
+    assert items
+    _required_keys(items[0])
+    item = lot_stub.get_item("lot1")
+    assert item and item["id"] == "lot1"
+
+
+def test_lendengine_stub_search_and_get():
+    items = lendengine_stub.search_items("Drill")
+    assert items
+    _required_keys(items[0])
+    item = lendengine_stub.get_item("le1")
+    assert item and item["id"] == "le1"
+
+
+def test_sanitize_raw_bounds_size():
+    raw = {"a": "x" * 5000, "b": list(range(1000))}
+    san = adapter.sanitize_raw(raw, max_bytes=2000)
+    assert len(json.dumps(san)) <= 2000
+
+
+def test_dispatcher_with_myturn_fixture():
+    results = client.search_items("myturn", "Hammer", use_fixture=True)
+    assert results and results[0]["provider"] == "myturn"
+    first_id = results[0]["id"]
+    item = client.get_item("myturn", first_id, use_fixture=True)
+    assert item and item["id"] == first_id
+
+
+def test_bad_provider():
+    with pytest.raises(client.ProviderNotAvailableError):
+        client.search_items("nope", "x")


### PR DESCRIPTION
## Summary
- add self-contained Library of Things (UK) connector with in-module schema and dispatcher
- implement myTurn provider (opt-in live) and fixture stubs for LoT platform & Lend Engine
- provide CLI, docs, changelog, and offline/unit/live tests

## Testing
- `PYTHONPATH=. pytest tests/connectors/test_libraryofthings_uk_unit.py`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68be08cae6308321b38a9730fc2ee79f