### PR TITLE
feat(connectors): add Fairtrade Product Finder connector

### DIFF
--- a/changelog/feat-connector-fairtrade-product-finder.md
+++ b/changelog/feat-connector-fairtrade-product-finder.md
@@ -1,0 +1,1 @@
+feat(connectors): add isolated Fairtrade Product Finder connector (UK/global fixtures + opt-in CSV provider); includes CLI, tests, docs

--- a/connectors/fairtrade_product_finder/README.md
+++ b/connectors/fairtrade_product_finder/README.md
@@ -1,0 +1,50 @@
+# Fairtrade Product Finder Connector
+
+This connector returns Fairtrade-certified products from multiple sources. It
+ships with two small fixture providers and an optional CSV provider for "live"
+usage.
+
+## Providers
+
+| Provider | Description |
+| --- | --- |
+| `fixtures_uk` | Hand-curated examples from the UK directory |
+| `fixtures_global` | Sample entries from the global directory |
+| `csv` | Loads a CSV export via `FAIRTRADE_CSV_URL` or `FAIRTRADE_CSV_PATH` |
+
+## Environment variables
+
+- `FAIRTRADE_CSV_URL` – HTTPS URL to a CSV export
+- `FAIRTRADE_CSV_PATH` – local path to a CSV export
+- `FAIRTRADE_TIMEOUT_SECONDS` – request timeout (default: 10)
+- `FAIRTRADE_RPS` – requests per second throttle for remote CSV (default: 3)
+
+## CSV header mapping
+
+| Header | Notes |
+| --- | --- |
+| `name` | Product name |
+| `brand` | Brand owner |
+| `category` | Category text |
+| `gtin` | EAN/UPC code |
+| `country` | Single or `;` separated markets |
+| `image_url` | Optional image URL |
+| `page_url` | Optional public page |
+| `licensee` | Licence holder |
+| `floid` | Fairtrade Organisation ID |
+| `validity_from` | Certification start (ISO8601) |
+| `validity_to` | Certification end (ISO8601) |
+| `status` | `valid` or `expired` |
+
+## Troubleshooting
+
+- Either `FAIRTRADE_CSV_URL` or `FAIRTRADE_CSV_PATH` must be set for the CSV
+  provider.
+- Remote fetches use a conservative token bucket so large files may take a
+  while to download.
+- Unknown headers are ignored; ensure required fields are present.
+
+## Contributing fixtures
+
+Keep fixtures small. Add new examples under `fixtures/` and extend tests where
+appropriate.

--- a/connectors/fairtrade_product_finder/__init__.py
+++ b/connectors/fairtrade_product_finder/__init__.py
@@ -1,0 +1,1 @@
+"""Fairtrade Product Finder connector package."""

--- a/connectors/fairtrade_product_finder/adapter.py
+++ b/connectors/fairtrade_product_finder/adapter.py
@@ -1,0 +1,88 @@
+"""Normalize Fairtrade sources to ``FairtradeProductV0``."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from typing import Dict, List, Optional, TypedDict
+
+
+class Certification(TypedDict, total=False):
+    scheme: str
+    floid: Optional[str]
+    licensee: Optional[str]
+    status: Optional[str]
+    valid_from: Optional[str]
+    valid_to: Optional[str]
+    scope: Optional[str]
+
+
+class ProductId(TypedDict, total=False):
+    gtins: List[str]
+    sku: Optional[str]
+
+
+class Price(TypedDict, total=False):
+    value: Optional[float]
+    currency: Optional[str]
+    unit: Optional[str]
+
+
+class BrandOwner(TypedDict, total=False):
+    brand: Optional[str]
+    manufacturer: Optional[str]
+
+
+class Provenance(TypedDict, total=False):
+    source_url: Optional[str]
+    fetched_at: Optional[str]
+    raw: Dict
+
+
+class FairtradeProductV0(TypedDict, total=False):
+    source: str
+    provider: str
+    id: str
+    name: Optional[str]
+    brand_owner: BrandOwner
+    categories: List[str]
+    product_ids: ProductId
+    country_markets: List[str]
+    images: List[str]
+    url: Optional[str]
+    price: Price
+    certification: Certification
+    provenance: Provenance
+
+
+def sanitize_raw(raw: dict, max_bytes: int = 30000) -> dict:
+    """Trim large values so provenance stays reasonably small.
+
+    Arrays and dictionaries are truncated to 20 items and long strings are
+    shortened to 1000 characters. If the resulting JSON encoding still exceeds
+    ``max_bytes`` the raw payload is discarded entirely.
+    """
+
+    def _trim(value):
+        if isinstance(value, list):
+            return [_trim(v) for v in value[:20]]
+        if isinstance(value, dict):
+            return {k: _trim(v) for k, v in list(value.items())[:20]}
+        if isinstance(value, str) and len(value) > 1000:
+            return value[:1000]
+        return value
+
+    trimmed = _trim(raw)
+    try:
+        encoded = json.dumps(trimmed).encode("utf-8")
+    except Exception:
+        return {}
+    if len(encoded) > max_bytes:
+        return {}
+    return trimmed
+
+
+def iso_now() -> str:
+    """Return a UTC timestamp in ISO8601 format with ``Z`` suffix."""
+
+    return _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"

--- a/connectors/fairtrade_product_finder/cli.py
+++ b/connectors/fairtrade_product_finder/cli.py
@@ -1,0 +1,80 @@
+"""JSONL CLI for the Fairtrade Product Finder connector."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from . import client
+from .providers import csv_provider
+
+
+def _emit(items):
+    for item in items:
+        print(json.dumps(item))
+
+
+def _cmd_search(args):
+    try:
+        items = client.search_products(
+            args.provider,
+            args.q,
+            brand=args.brand,
+            country=args.country,
+            limit=args.limit,
+            offset=args.offset,
+        )
+    except (client.ProviderNotAvailableError, csv_provider.CsvLoadError) as exc:
+        sys.exit(str(exc))
+    _emit(items)
+
+
+def _cmd_item(args):
+    try:
+        item = client.get_product(args.provider, args.id)
+    except (client.ProviderNotAvailableError, csv_provider.CsvLoadError) as exc:
+        sys.exit(str(exc))
+    if item:
+        print(json.dumps(item))
+
+
+def _cmd_gtin(args):
+    try:
+        item = client.lookup_by_gtin(args.provider, args.gtin)
+    except (client.ProviderNotAvailableError, csv_provider.CsvLoadError) as exc:
+        sys.exit(str(exc))
+    if item:
+        print(json.dumps(item))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="fairtrade_product_finder")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_search = sub.add_parser("search", help="search products")
+    p_search.add_argument("--provider", required=True)
+    p_search.add_argument("--q", required=True)
+    p_search.add_argument("--brand")
+    p_search.add_argument("--country")
+    p_search.add_argument("--limit", type=int, default=20)
+    p_search.add_argument("--offset", type=int, default=0)
+    p_search.set_defaults(func=_cmd_search)
+
+    p_item = sub.add_parser("item", help="get product by id")
+    p_item.add_argument("--provider", required=True)
+    p_item.add_argument("--id", required=True)
+    p_item.set_defaults(func=_cmd_item)
+
+    p_gtin = sub.add_parser("gtin", help="lookup by GTIN")
+    p_gtin.add_argument("--provider", required=True)
+    p_gtin.add_argument("--gtin", required=True)
+    p_gtin.set_defaults(func=_cmd_gtin)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/connectors/fairtrade_product_finder/client.py
+++ b/connectors/fairtrade_product_finder/client.py
@@ -1,0 +1,67 @@
+"""Provider dispatcher for the Fairtrade Product Finder connector."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Optional
+
+from .providers import fixtures_uk, fixtures_global, csv_provider
+
+__all__ = [
+    "ProviderNotAvailableError",
+    "search_products",
+    "get_product",
+    "lookup_by_gtin",
+]
+
+
+class ProviderNotAvailableError(Exception):
+    """Raised when a provider is not available."""
+
+
+_PROVIDERS = {
+    "fixtures_uk": fixtures_uk,
+    "fixtures_global": fixtures_global,
+    "csv": csv_provider,
+}
+
+
+def _get_provider(name: str):
+    try:
+        return _PROVIDERS[name]
+    except KeyError as exc:
+        raise ProviderNotAvailableError(name) from exc
+
+
+def search_products(
+    provider: str,
+    query: str,
+    *,
+    brand: str | None = None,
+    country: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs,
+) -> List[Dict]:
+    """Dispatch ``search_products`` to ``providers.{provider}``."""
+
+    mod = _get_provider(provider)
+    return mod.search_products(
+        query, brand=brand, country=country, limit=limit, offset=offset, **kwargs
+    )
+
+
+def get_product(provider: str, product_id: str, **kwargs) -> Optional[Dict]:
+    """Dispatch ``get_product`` to ``providers.{provider}``."""
+
+    mod = _get_provider(provider)
+    return mod.get_product(product_id, **kwargs)
+
+
+def lookup_by_gtin(provider: str, gtin: str, **kwargs) -> Optional[Dict]:
+    """Convenience lookup by GTIN for ``provider``."""
+
+    mod = _get_provider(provider)
+    func = getattr(mod, "lookup_by_gtin", None)
+    if func is None:
+        return None
+    return func(gtin, **kwargs)

--- a/connectors/fairtrade_product_finder/fixtures/global_directory.json
+++ b/connectors/fairtrade_product_finder/fixtures/global_directory.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "GL-FT-1001",
+    "name": "Global Coffee Beans",
+    "brand": "World Cafe",
+    "category": "coffee",
+    "gtins": ["4023456789012"],
+    "country_markets": ["DE", "AT"],
+    "images": ["https://example.com/global-coffee.jpg"],
+    "url": "https://directory.fairtrade.net/product/coffee-1",
+    "licensee": "World Cafe GmbH",
+    "floid": "987654",
+    "valid_from": "2023-01-01",
+    "valid_to": "2024-12-31",
+    "status": "valid"
+  },
+  {
+    "id": "GL-FT-1002",
+    "name": "Fairtrade Sugar",
+    "brand": "Sweet Co",
+    "category": "sugar",
+    "gtins": ["4001111000002"],
+    "country_markets": ["US", "CA"],
+    "images": ["https://example.com/sugar.jpg"],
+    "url": "https://directory.fairtrade.net/product/sugar-1",
+    "licensee": "Sweet Co Inc",
+    "floid": "987655",
+    "valid_from": "2022-01-01",
+    "valid_to": "2023-12-31",
+    "status": "expired"
+  },
+  {
+    "id": "GL-FT-1003",
+    "name": "Banana Chips",
+    "brand": "Tropicana",
+    "category": "snacks",
+    "gtins": ["4012345678901"],
+    "country_markets": ["FR", "BE", "NL"],
+    "images": ["https://example.com/banana-chips.jpg"],
+    "url": "https://directory.fairtrade.net/product/banana-1",
+    "licensee": "Tropicana Foods",
+    "floid": "987656",
+    "valid_from": "2021-05-01",
+    "valid_to": "2024-05-01",
+    "status": "valid"
+  }
+]

--- a/connectors/fairtrade_product_finder/fixtures/sample_catalog.csv
+++ b/connectors/fairtrade_product_finder/fixtures/sample_catalog.csv
@@ -1,0 +1,4 @@
+name,brand,category,gtin,country,image_url,page_url,licensee,floid,validity_from,validity_to,status
+Fairtrade Instant Coffee,Cafe Example,coffee,5012345678900,UK,https://example.com/coffee.jpg,https://example.com/coffee,Cafe Example Ltd,UK123,2023-01-01,2024-12-31,valid
+Organic Black Tea,Clipper,tea,5021991001234,UK,https://example.com/tea.jpg,https://example.com/tea,Tea Makers Co,UK124,2022-06-01,2024-06-01,valid
+Dark Chocolate Bar,Choco Bliss,chocolate,5033333000000,UK,https://example.com/choc.jpg,https://example.com/choc,Choco Bliss Ltd,UK125,2023-02-01,2025-02-01,valid

--- a/connectors/fairtrade_product_finder/fixtures/uk_directory.json
+++ b/connectors/fairtrade_product_finder/fixtures/uk_directory.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "UK-FT-0001",
+    "name": "Fairtrade Ground Coffee",
+    "brand": "Cafe Example",
+    "category": "coffee",
+    "gtins": ["5012345678900"],
+    "country_markets": ["UK"],
+    "images": ["https://example.com/coffee.jpg"],
+    "url": "https://www.fairtrade.org.uk/directory/coffee-1",
+    "licensee": "Cafe Example Ltd",
+    "floid": "UK123",
+    "valid_from": "2023-01-01",
+    "valid_to": "2024-12-31",
+    "status": "valid"
+  },
+  {
+    "id": "UK-FT-0002",
+    "name": "Organic Green Tea",
+    "brand": "Clipper",
+    "category": "tea",
+    "gtins": ["5021991001234"],
+    "country_markets": ["UK"],
+    "images": ["https://example.com/green-tea.jpg"],
+    "url": "https://www.fairtrade.org.uk/directory/tea-1",
+    "licensee": "Tea Makers Co",
+    "floid": "UK124",
+    "valid_from": "2022-06-01",
+    "valid_to": "2024-06-01",
+    "status": "valid"
+  },
+  {
+    "id": "UK-FT-0003",
+    "name": "Dark Chocolate Bar",
+    "brand": "Choco Bliss",
+    "category": "chocolate",
+    "gtins": ["5033333000000"],
+    "country_markets": ["UK"],
+    "images": ["https://example.com/chocolate.jpg"],
+    "url": "https://www.fairtrade.org.uk/directory/chocolate-1",
+    "licensee": "Choco Bliss Ltd",
+    "floid": "UK125",
+    "valid_from": "2023-02-01",
+    "valid_to": "2025-02-01",
+    "status": "valid"
+  }
+]

--- a/connectors/fairtrade_product_finder/providers/__init__.py
+++ b/connectors/fairtrade_product_finder/providers/__init__.py
@@ -1,0 +1,5 @@
+"""Provider implementations for the Fairtrade Product Finder connector."""
+
+from . import fixtures_uk, fixtures_global, csv_provider
+
+__all__ = ["fixtures_uk", "fixtures_global", "csv_provider"]

--- a/connectors/fairtrade_product_finder/providers/csv_provider.py
+++ b/connectors/fairtrade_product_finder/providers/csv_provider.py
@@ -1,0 +1,173 @@
+"""CSV provider for Fairtrade Product Finder.
+
+Data is loaded from a CSV export either via ``FAIRTRADE_CSV_URL`` or a local
+file via ``FAIRTRADE_CSV_PATH``. The module performs a small token-bucket
+throttle for remote requests and maps rows to ``FairtradeProductV0`` objects.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import random
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from typing import Dict, List, Optional
+
+from ..adapter import FairtradeProductV0, sanitize_raw, iso_now
+
+__all__ = ["CsvLoadError", "search_products", "get_product", "lookup_by_gtin"]
+
+USER_AGENT = (
+    "circl-fairtrade-csv/0.1 "
+    "(+https://github.com/andremair97/circl-docs)"
+)
+
+
+class CsvLoadError(Exception):
+    """Raised when the CSV source cannot be loaded."""
+
+
+_tokens: float = 0.0
+_last: float = time.monotonic()
+_rows: Optional[List[Dict[str, str]]] = None
+_source_url: Optional[str] = None
+
+
+def _throttle() -> None:
+    global _tokens, _last
+    rate = float(os.getenv("FAIRTRADE_RPS", "3"))
+    capacity = max(rate, 1.0)
+    now = time.monotonic()
+    elapsed = now - _last
+    _tokens = min(capacity, _tokens + elapsed * rate)
+    if _tokens < 1:
+        wait = (1 - _tokens) / rate
+        time.sleep(wait + random.uniform(0, 0.1))
+        now = time.monotonic()
+        elapsed = now - _last
+        _tokens = min(capacity, _tokens + elapsed * rate)
+    _tokens -= 1
+    _last = now
+
+
+def _load_rows() -> List[Dict[str, str]]:
+    global _rows, _source_url
+    if _rows is not None:
+        return _rows
+
+    path = os.getenv("FAIRTRADE_CSV_PATH")
+    url = os.getenv("FAIRTRADE_CSV_URL")
+    if not path and not url:
+        raise CsvLoadError("FAIRTRADE_CSV_URL or FAIRTRADE_CSV_PATH required")
+
+    if path:
+        _source_url = path
+        fh = open(path, "r", encoding="utf-8")
+    else:
+        _throttle()
+        headers = {"User-Agent": USER_AGENT, "Accept": "text/csv, */*"}
+        req = urllib.request.Request(url, headers=headers)
+        timeout = float(os.getenv("FAIRTRADE_TIMEOUT_SECONDS", "10"))
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                status = getattr(resp, "status", resp.getcode())
+                if status != 200:
+                    raise CsvLoadError(f"HTTP {status} for {url}")
+                with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                    while True:
+                        chunk = resp.read(8192)
+                        if not chunk:
+                            break
+                        tmp.write(chunk)
+                    tmp_path = tmp.name
+        except urllib.error.URLError as exc:  # pragma: no cover - network failure
+            raise CsvLoadError(str(exc)) from exc
+        fh = open(tmp_path, "r", encoding="utf-8")
+        _source_url = url
+
+    with fh:
+        reader = csv.DictReader(fh)
+        _rows = [row for row in reader]
+    return _rows
+
+
+def _map(row: Dict[str, str]) -> FairtradeProductV0:
+    gtin = (row.get("gtin") or "").strip()
+    categories = [row["category"].strip()] if row.get("category") else []
+    countries = []
+    if row.get("country"):
+        countries = [c.strip() for c in row["country"].split(";") if c.strip()]
+    images = [row["image_url"].strip()] if row.get("image_url") else []
+    return {
+        "source": "fairtrade:csv",
+        "provider": "csv",
+        "id": gtin or (row.get("name") or ""),
+        "name": row.get("name"),
+        "brand_owner": {"brand": row.get("brand")},
+        "categories": categories,
+        "product_ids": {"gtins": [gtin] if gtin else []},
+        "country_markets": countries,
+        "images": images,
+        "url": row.get("page_url"),
+        "price": {},
+        "certification": {
+            "scheme": "Fairtrade",
+            "floid": row.get("floid"),
+            "licensee": row.get("licensee"),
+            "status": row.get("status"),
+            "valid_from": row.get("validity_from"),
+            "valid_to": row.get("validity_to"),
+        },
+        "provenance": {
+            "source_url": _source_url,
+            "fetched_at": iso_now(),
+            "raw": sanitize_raw(row),
+        },
+    }
+
+
+def search_products(
+    query: str,
+    brand: str | None = None,
+    country: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs,
+) -> List[FairtradeProductV0]:
+    rows = _load_rows()
+    query_l = query.lower()
+    out: List[FairtradeProductV0] = []
+    for row in rows:
+        if brand and (row.get("brand") or "").lower() != brand.lower():
+            continue
+        if country:
+            countries = [c.strip() for c in (row.get("country") or "").split(";") if c.strip()]
+            if country not in countries:
+                continue
+        text = " ".join(
+            [row.get("name", ""), row.get("brand", ""), row.get("category", "")]
+        ).lower()
+        if query_l not in text:
+            continue
+        out.append(_map(row))
+    return out[offset : offset + limit]
+
+
+def get_product(product_id: str, **kwargs) -> Optional[FairtradeProductV0]:
+    rows = _load_rows()
+    for row in rows:
+        rid = (row.get("gtin") or row.get("name") or "").strip()
+        if rid == product_id:
+            return _map(row)
+    return None
+
+
+def lookup_by_gtin(gtin: str, **kwargs) -> Optional[FairtradeProductV0]:
+    rows = _load_rows()
+    for row in rows:
+        if (row.get("gtin") or "").strip() == gtin:
+            return _map(row)
+    return None

--- a/connectors/fairtrade_product_finder/providers/fixtures_global.py
+++ b/connectors/fairtrade_product_finder/providers/fixtures_global.py
@@ -1,0 +1,93 @@
+"""Fixture provider for the global Fairtrade directory."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List, Optional
+
+from ..adapter import FairtradeProductV0, sanitize_raw, iso_now
+
+__all__ = ["search_products", "get_product", "lookup_by_gtin"]
+
+_FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "fixtures", "global_directory.json"
+)
+_data: Optional[List[Dict]] = None
+
+
+def _load() -> List[Dict]:
+    global _data
+    if _data is None:
+        with open(_FIXTURE_PATH, "r", encoding="utf-8") as fh:
+            _data = json.load(fh)
+    return _data
+
+
+def _map(item: Dict) -> FairtradeProductV0:
+    return {
+        "source": "fairtrade:global-fixtures",
+        "provider": "fixtures_global",
+        "id": str(item.get("id", "")),
+        "name": item.get("name"),
+        "brand_owner": {"brand": item.get("brand")},
+        "categories": [item.get("category")] if item.get("category") else [],
+        "product_ids": {"gtins": item.get("gtins", [])},
+        "country_markets": item.get("country_markets", []),
+        "images": item.get("images", []),
+        "url": item.get("url"),
+        "price": {},
+        "certification": {
+            "scheme": "Fairtrade",
+            "floid": item.get("floid"),
+            "licensee": item.get("licensee"),
+            "status": item.get("status"),
+            "valid_from": item.get("valid_from"),
+            "valid_to": item.get("valid_to"),
+            "scope": "International",
+        },
+        "provenance": {
+            "source_url": item.get("url"),
+            "fetched_at": iso_now(),
+            "raw": sanitize_raw(item),
+        },
+    }
+
+
+def search_products(
+    query: str,
+    brand: str | None = None,
+    country: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs,
+) -> List[FairtradeProductV0]:
+    data = _load()
+    query_l = query.lower()
+    out: List[FairtradeProductV0] = []
+    for item in data:
+        if brand and item.get("brand", "").lower() != brand.lower():
+            continue
+        if country and country not in item.get("country_markets", []):
+            continue
+        text = " ".join(
+            [item.get("name", ""), item.get("brand", ""), item.get("category", "")]
+        ).lower()
+        if query_l not in text:
+            continue
+        out.append(_map(item))
+    return out[offset : offset + limit]
+
+
+def get_product(product_id: str, **kwargs) -> Optional[FairtradeProductV0]:
+    for item in _load():
+        if str(item.get("id")) == str(product_id):
+            return _map(item)
+    return None
+
+
+def lookup_by_gtin(gtin: str, **kwargs) -> Optional[FairtradeProductV0]:
+    for item in _load():
+        if gtin in item.get("gtins", []):
+            return _map(item)
+    return None

--- a/connectors/fairtrade_product_finder/providers/fixtures_uk.py
+++ b/connectors/fairtrade_product_finder/providers/fixtures_uk.py
@@ -1,0 +1,93 @@
+"""Fixture provider for the UK Fairtrade Product Finder."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List, Optional
+
+from ..adapter import FairtradeProductV0, sanitize_raw, iso_now
+
+__all__ = ["search_products", "get_product", "lookup_by_gtin"]
+
+_FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "fixtures", "uk_directory.json"
+)
+_data: Optional[List[Dict]] = None
+
+
+def _load() -> List[Dict]:
+    global _data
+    if _data is None:
+        with open(_FIXTURE_PATH, "r", encoding="utf-8") as fh:
+            _data = json.load(fh)
+    return _data
+
+
+def _map(item: Dict) -> FairtradeProductV0:
+    return {
+        "source": "fairtrade:uk-fixtures",
+        "provider": "fixtures_uk",
+        "id": str(item.get("id", "")),
+        "name": item.get("name"),
+        "brand_owner": {"brand": item.get("brand")},
+        "categories": [item.get("category")] if item.get("category") else [],
+        "product_ids": {"gtins": item.get("gtins", [])},
+        "country_markets": item.get("country_markets", []),
+        "images": item.get("images", []),
+        "url": item.get("url"),
+        "price": {},
+        "certification": {
+            "scheme": "Fairtrade",
+            "floid": item.get("floid"),
+            "licensee": item.get("licensee"),
+            "status": item.get("status"),
+            "valid_from": item.get("valid_from"),
+            "valid_to": item.get("valid_to"),
+            "scope": "UK",
+        },
+        "provenance": {
+            "source_url": item.get("url"),
+            "fetched_at": iso_now(),
+            "raw": sanitize_raw(item),
+        },
+    }
+
+
+def search_products(
+    query: str,
+    brand: str | None = None,
+    country: str | None = "UK",
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs,
+) -> List[FairtradeProductV0]:
+    data = _load()
+    query_l = query.lower()
+    out: List[FairtradeProductV0] = []
+    for item in data:
+        if brand and item.get("brand", "").lower() != brand.lower():
+            continue
+        if country and country not in item.get("country_markets", []):
+            continue
+        text = " ".join(
+            [item.get("name", ""), item.get("brand", ""), item.get("category", "")]
+        ).lower()
+        if query_l not in text:
+            continue
+        out.append(_map(item))
+    return out[offset : offset + limit]
+
+
+def get_product(product_id: str, **kwargs) -> Optional[FairtradeProductV0]:
+    for item in _load():
+        if str(item.get("id")) == str(product_id):
+            return _map(item)
+    return None
+
+
+def lookup_by_gtin(gtin: str, **kwargs) -> Optional[FairtradeProductV0]:
+    for item in _load():
+        if gtin in item.get("gtins", []):
+            return _map(item)
+    return None

--- a/docs/connectors/fairtrade_product_finder.md
+++ b/docs/connectors/fairtrade_product_finder.md
@@ -1,0 +1,46 @@
+# Fairtrade Product Finder
+
+The Fairtrade Product Finder connector returns Fairtrade-certified products and
+licensees. Official directories exist for the [Fairtrade Finder](https://www.fairtrade.org.uk/fairtrade-products/)
+and [FLOCERT customer search](https://www.flocert.net/solutions/fairtrade-services/fairtrade-customer-search/)
+but they do not expose public JSON APIs. This module therefore ships with small
+fixture providers and an optional CSV provider for live datasets.
+
+## Providers
+
+- `fixtures_uk` – small UK examples
+- `fixtures_global` – global sample entries
+- `csv` – opt-in CSV export via `FAIRTRADE_CSV_URL` or `FAIRTRADE_CSV_PATH`
+
+## CLI
+
+```bash
+python -m connectors.fairtrade_product_finder.cli search --provider fixtures_uk --q "coffee" --limit 5
+python -m connectors.fairtrade_product_finder.cli item --provider fixtures_uk --id "UK-FT-0001"
+python -m connectors.fairtrade_product_finder.cli gtin --provider csv --gtin 5051234567890
+```
+
+## Normalised output
+
+```json
+{
+  "source": "fairtrade:uk-fixtures",
+  "provider": "fixtures_uk",
+  "id": "UK-FT-0001",
+  "name": "Fairtrade Ground Coffee",
+  "brand_owner": {"brand": "Cafe Example"},
+  "categories": ["coffee"],
+  "product_ids": {"gtins": ["5012345678900"]},
+  "country_markets": ["UK"],
+  "images": ["https://example.com/coffee.jpg"],
+  "url": "https://www.fairtrade.org.uk/directory/coffee-1",
+  "price": {},
+  "certification": {"scheme": "Fairtrade", "licensee": "Cafe Example Ltd", "scope": "UK"},
+  "provenance": {"source_url": "https://www.fairtrade.org.uk/directory/coffee-1"}
+}
+```
+
+## Notes
+
+Use a polite User-Agent and keep request rates low when using the CSV provider.
+Fixtures should remain small to keep the repository lightweight.

--- a/tests/connectors/test_fairtrade_product_finder_live_csv.py
+++ b/tests/connectors/test_fairtrade_product_finder_live_csv.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+
+from connectors.fairtrade_product_finder import client
+
+skip_reason = "live CSV not configured"
+requires_env = (
+    os.getenv("FT_LIVE_TEST") == "1"
+    and (os.getenv("FAIRTRADE_CSV_URL") or os.getenv("FAIRTRADE_CSV_PATH"))
+)
+
+
+@pytest.mark.skipif(not requires_env, reason=skip_reason)
+def test_live_csv_search_smoke():
+    items = client.search_products("csv", "coffee", limit=2)
+    assert items
+    item = items[0]
+    assert item.get("id")
+    assert item.get("name")
+    gtins = item.get("product_ids", {}).get("gtins", [])
+    assert isinstance(gtins, list)

--- a/tests/connectors/test_fairtrade_product_finder_unit.py
+++ b/tests/connectors/test_fairtrade_product_finder_unit.py
@@ -1,0 +1,43 @@
+import json
+import pytest
+
+from connectors.fairtrade_product_finder import adapter, client
+
+
+REQUIRED_KEYS = {
+    "source",
+    "provider",
+    "id",
+    "name",
+    "product_ids",
+    "certification",
+    "provenance",
+}
+
+
+def _check_shape(item):
+    for key in REQUIRED_KEYS:
+        assert key in item
+
+
+def test_fixture_provider_shape():
+    items = client.search_products("fixtures_uk", "coffee")
+    assert items
+    _check_shape(items[0])
+    items_g = client.search_products("fixtures_global", "coffee")
+    assert items_g
+    _check_shape(items_g[0])
+
+
+def test_sanitize_raw_bounds():
+    raw = {"big": ["x" * 2000] * 100}
+    cleaned = adapter.sanitize_raw(raw, max_bytes=2000)
+    size = len(json.dumps(cleaned).encode("utf-8"))
+    assert size <= 2000
+
+
+def test_dispatcher_and_lookup():
+    item = client.lookup_by_gtin("fixtures_uk", "5012345678900")
+    assert item and item["id"] == "UK-FT-0001"
+    with pytest.raises(client.ProviderNotAvailableError):
+        client.search_products("nope", "coffee")


### PR DESCRIPTION
## Summary
- add self-contained Fairtrade Product Finder connector (UK & global fixtures, CSV provider)
- expose JSONL CLI and docs for searching, item lookup, and GTIN lookup
- cover fixtures with unit tests and provide opt-in live CSV smoke test

## Testing
- `python -m pytest tests/connectors/test_fairtrade_product_finder_unit.py`
- `FT_LIVE_TEST=1 FAIRTRADE_CSV_PATH=connectors/fairtrade_product_finder/fixtures/sample_catalog.csv python -m pytest tests/connectors/test_fairtrade_product_finder_live_csv.py`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68be09fe48f4832186d1d112a0b91549