### PR TITLE
feat(connectors): add TCO Certified connector

### DIFF
--- a/changelog.d/feat-connector-tco-certified.md
+++ b/changelog.d/feat-connector-tco-certified.md
@@ -1,0 +1,1 @@
+feat(connectors): add isolated TCO Certified connector with GTIN API (opt-in live), CSV loader, and Product Finder fixture stub; includes CLI, tests, and docs

--- a/connectors/tco_certified/README.md
+++ b/connectors/tco_certified/README.md
@@ -1,0 +1,25 @@
+# TCO Certified Connector
+
+Isolated connector that surfaces basic certificate metadata from TCO Certified.
+It ships with three providers:
+
+- **GTIN API** – opt-in live lookup by GTIN via `TCO_GTIN_API_BASE`
+- **CSV loader** – local exports, no network
+- **Product Finder stub** – small fixture for offline development
+
+All providers normalise to the in-module `UniversalCertificationV0` shape.
+
+## Maintainer quick commands
+
+```bash
+# Unit tests (offline)
+python -m pytest tests/connectors/test_tco_certified_unit.py -q
+
+# Opt-in live GTIN test
+TCO_LIVE_TEST=1 TCO_GTIN_API_BASE="https://industry.tcocertified.com/gtin-api" \
+  python -m pytest tests/connectors/test_tco_certified_live_gtin.py -q
+
+# CLI examples
+python -m connectors.tco_certified.cli search --provider csv --q "Dell" --path connectors/tco_certified/fixtures/certificates_sample.csv
+python -m connectors.tco_certified.cli search --provider productfinder-stub --q display
+```

--- a/connectors/tco_certified/__init__.py
+++ b/connectors/tco_certified/__init__.py
@@ -1,0 +1,1 @@
+"""TCO Certified connector package."""

--- a/connectors/tco_certified/adapter.py
+++ b/connectors/tco_certified/adapter.py
@@ -1,0 +1,143 @@
+"""Normalize TCO Certified payloads into ``UniversalCertificationV0``.
+
+Each provider maps its raw responses through ``normalize`` to produce a stable
+shape for downstream consumers. Provenance keeps a truncated copy of the raw
+payload so callers can audit source data without bloating memory.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Any, Dict, List, Optional, TypedDict
+
+__all__ = [
+    "Links",
+    "Validity",
+    "UniversalCertificationV0",
+    "sanitize_raw",
+    "iso_now",
+    "coerce_date",
+    "listify_gtins",
+    "normalize",
+]
+
+
+class Links(TypedDict, total=False):
+    product_finder: Optional[str]
+    certificate_pdf: Optional[str]
+    product_page: Optional[str]
+
+
+class Validity(TypedDict, total=False):
+    valid_from: Optional[str]
+    valid_to: Optional[str]
+    status: Optional[str]
+
+
+class UniversalCertificationV0(TypedDict, total=False):
+    source: str
+    provider: str
+    id: str
+    certificate_number: Optional[str]
+    generation: Optional[str]
+    category: Optional[str]
+    brand: Optional[str]
+    model: Optional[str]
+    gtins: List[str]
+    validity: Validity
+    links: Links
+    attributes: Dict[str, Any]
+    provenance: Dict[str, Any]
+
+
+def iso_now() -> str:
+    """Return a UTC timestamp truncated to seconds."""
+
+    return _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def coerce_date(value: Any) -> Optional[str]:
+    """Return ``value`` as ISO8601 date if possible."""
+
+    if not value:
+        return None
+    try:
+        return str(_dt.date.fromisoformat(str(value)))
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def listify_gtins(value: Any) -> List[str]:
+    """Turn ``value`` into a list of GTIN strings."""
+
+    if not value:
+        return []
+    if isinstance(value, list):
+        items = value
+    elif isinstance(value, str):
+        if "|" in value:
+            items = value.split("|")
+        elif "," in value:
+            items = value.split(",")
+        else:
+            items = [value]
+    else:
+        items = [str(value)]
+    return [str(i).strip() for i in items if str(i).strip()]
+
+
+def sanitize_raw(raw: Dict[str, Any], max_bytes: int = 30000) -> Dict[str, Any]:
+    """Recursively trim large structures for provenance.
+
+    ``max_bytes`` applies to string representations, providing a hard ceiling so
+    oversized payloads do not leak into logs or provenance stores.
+    """
+
+    def _trim(value: Any) -> Any:
+        if isinstance(value, list):
+            return [_trim(v) for v in value[:20]]
+        if isinstance(value, dict):
+            return {k: _trim(v) for k, v in list(value.items())[:20]}
+        if isinstance(value, str) and len(value.encode("utf-8")) > max_bytes:
+            return value.encode("utf-8")[:max_bytes].decode("utf-8", "ignore")
+        return value
+
+    return _trim(raw)
+
+
+def normalize(raw: Dict[str, Any], provider: str, source: str) -> UniversalCertificationV0:
+    """Normalise ``raw`` dict into ``UniversalCertificationV0``."""
+
+    gtins = listify_gtins(raw.get("gtins"))
+    validity = {
+        "valid_from": coerce_date(raw.get("valid_from")),
+        "valid_to": coerce_date(raw.get("valid_to")),
+        "status": raw.get("status"),
+    }
+    links = {
+        k: raw.get(k)
+        for k in ["product_finder", "certificate_pdf", "product_page"]
+        if raw.get(k)
+    }
+    item: UniversalCertificationV0 = {
+        "source": source,
+        "provider": provider,
+        "id": raw.get("certificate_number")
+        or "|".join(filter(None, [raw.get("brand"), raw.get("model")]))
+        or (gtins[0] if gtins else ""),
+        "certificate_number": raw.get("certificate_number"),
+        "generation": raw.get("generation"),
+        "category": raw.get("category"),
+        "brand": raw.get("brand"),
+        "model": raw.get("model"),
+        "gtins": gtins,
+        "validity": {k: v for k, v in validity.items() if v},
+        "links": links,  # type: ignore[assignment]
+        "attributes": raw.get("attributes", {}),
+        "provenance": {
+            "source_url": raw.get("source_url"),
+            "fetched_at": raw.get("fetched_at") or iso_now(),
+            "raw": sanitize_raw(raw.get("raw", {})),
+        },
+    }
+    return item

--- a/connectors/tco_certified/cli.py
+++ b/connectors/tco_certified/cli.py
@@ -1,0 +1,87 @@
+"""JSONL CLI for the TCO Certified connector."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from . import client
+from .client import ProviderNotAvailableError
+from .providers.gtin_api import TcoGtinHttpError, TcoGtinParseError
+
+
+def _print_jsonl(items: list[dict]) -> None:
+    for item in items:
+        print(json.dumps(item, ensure_ascii=False))
+
+
+def cmd_search(args: argparse.Namespace) -> int:
+    try:
+        items = client.search(
+            provider=args.provider,
+            q=args.q,
+            brand=args.brand,
+            model=args.model,
+            category=args.category,
+            gtin=args.gtin,
+            limit=args.limit,
+            offset=args.offset,
+            path=getattr(args, "path", None),
+            fixture_path=getattr(args, "fixture_path", None),
+        )
+    except (ProviderNotAvailableError, TcoGtinHttpError, TcoGtinParseError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    _print_jsonl(items)
+    return 0
+
+
+def cmd_cert(args: argparse.Namespace) -> int:
+    try:
+        item = client.get_by_certificate(
+            provider=args.provider, certificate_number=args.id, path=getattr(args, "path", None)
+        )
+    except (ProviderNotAvailableError, TcoGtinHttpError, TcoGtinParseError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    if item:
+        print(json.dumps(item, ensure_ascii=False))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="tco-cert")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--provider", required=True, choices=["gtin-api", "csv", "productfinder-stub"])
+
+    sp = sub.add_parser("search", parents=[common])
+    sp.add_argument("--q")
+    sp.add_argument("--brand")
+    sp.add_argument("--model")
+    sp.add_argument("--category")
+    sp.add_argument("--gtin")
+    sp.add_argument("--limit", type=int, default=20)
+    sp.add_argument("--offset", type=int, default=0)
+    sp.add_argument("--path")
+    sp.add_argument("--fixture-path")
+    sp.set_defaults(func=cmd_search)
+
+    cp = sub.add_parser("cert", parents=[common])
+    cp.add_argument("--id", required=True, help="certificate number")
+    cp.add_argument("--path")
+    cp.set_defaults(func=cmd_cert)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/connectors/tco_certified/client.py
+++ b/connectors/tco_certified/client.py
@@ -1,0 +1,85 @@
+"""Provider dispatcher for the TCO Certified connector.
+
+This thin layer routes calls to individual provider modules. New providers can
+be added without touching the public interface. The dispatcher validates that a
+requested provider is available and exposes a uniform API that returns
+``UniversalCertificationV0`` items.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, Callable, Dict, List
+
+from .adapter import UniversalCertificationV0
+
+__all__ = [
+    "ProviderNotAvailableError",
+    "search",
+    "get_by_certificate",
+]
+
+
+class ProviderNotAvailableError(Exception):
+    """Raised when a provider is not known to the dispatcher."""
+
+
+# Map provider names to import paths within this package.
+_PROVIDERS: Dict[str, str] = {
+    "gtin-api": "connectors.tco_certified.providers.gtin_api",
+    "csv": "connectors.tco_certified.providers.csv_loader",
+    "productfinder-stub": "connectors.tco_certified.providers.productfinder_stub",
+}
+
+
+def _get_provider(name: str) -> Any:
+    module_path = _PROVIDERS.get(name)
+    if not module_path:
+        raise ProviderNotAvailableError(name)
+    return import_module(module_path)
+
+
+def search(
+    provider: str,
+    q: str | None = None,
+    brand: str | None = None,
+    model: str | None = None,
+    category: str | None = None,
+    gtin: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs: Any,
+) -> List[UniversalCertificationV0]:
+    """Dispatch ``search`` calls to a provider.
+
+    Additional ``kwargs`` are forwarded verbatim. Providers are expected to be
+    forgiving and return best-effort normalised objects even when some optional
+    fields are missing.
+    """
+
+    module = _get_provider(provider)
+    func: Callable[..., List[UniversalCertificationV0]] = getattr(module, "search")
+    return func(
+        q=q,
+        brand=brand,
+        model=model,
+        category=category,
+        gtin=gtin,
+        limit=limit,
+        offset=offset,
+        **kwargs,
+    )
+
+
+def get_by_certificate(
+    provider: str,
+    certificate_number: str,
+    **kwargs: Any,
+) -> UniversalCertificationV0 | None:
+    """Dispatch ``get_by_certificate`` calls to a provider."""
+
+    module = _get_provider(provider)
+    func: Callable[..., UniversalCertificationV0 | None] = getattr(
+        module, "get_by_certificate"
+    )
+    return func(certificate_number=certificate_number, **kwargs)

--- a/connectors/tco_certified/fixtures/certificates_sample.csv
+++ b/connectors/tco_certified/fixtures/certificates_sample.csv
@@ -1,0 +1,5 @@
+certificate_number,brand,model,category,generation,valid_from,valid_to,status,gtins,product_finder,certificate_pdf,product_page,recycled_content_pct
+DE125060063,Dell,Latitude 7440,Notebooks,g10,2024-01-01,2027-12-31,valid,0884112345678|0884112345685,https://tcocertified.com/product/dell-latitude-7440,https://tcocertified.com/certificates/DE125060063.pdf,https://dell.com/latitude7440,40
+HP99887766,HP,Z24n G3,Displays,g10,2024-05-01,2026-04-30,valid,0190012345678,https://tcocertified.com/product/hp-z24n-g3,https://tcocertified.com/certificates/HP99887766.pdf,https://hp.com/z24n-g3,30
+LN12345678,Lenovo,ThinkCentre Neo 50s,Desktops,g10,2024-02-15,2027-02-14,valid,0196112345678,https://tcocertified.com/product/lenovo-neo50s,https://tcocertified.com/certificates/LN12345678.pdf,https://lenovo.com/neo50s,25
+SM55544433,Samsung,Galaxy Book3,Notebooks,g10,2024-03-01,2026-02-28,valid,0887276789012,https://tcocertified.com/product/samsung-galaxy-book3,https://tcocertified.com/certificates/SM55544433.pdf,https://samsung.com/galaxy-book3,20

--- a/connectors/tco_certified/fixtures/gtin_api_lookup.json
+++ b/connectors/tco_certified/fixtures/gtin_api_lookup.json
@@ -1,0 +1,19 @@
+{
+  "gtin": "0887276789012",
+  "certificate_number": "TC0X12345",
+  "brand": "ExampleBrand",
+  "model": "EcoDisplay 27",
+  "category": "Displays",
+  "generation": "g10",
+  "valid_from": "2024-01-01",
+  "valid_to": "2026-12-31",
+  "status": "valid",
+  "links": {
+    "product_finder": "https://tcocertified.com/product/123",
+    "certificate_pdf": "https://tcocertified.com/certificates/TC0X12345.pdf",
+    "product_page": "https://example.com/eco-display-27"
+  },
+  "attributes": {
+    "recycled_content_pct": 35
+  }
+}

--- a/connectors/tco_certified/fixtures/productfinder_stub_inventory.json
+++ b/connectors/tco_certified/fixtures/productfinder_stub_inventory.json
@@ -1,0 +1,47 @@
+[
+  {
+    "certificate_number": "DE125060063",
+    "brand": "Dell",
+    "model": "Latitude 7440",
+    "category": "Notebooks",
+    "generation": "g10",
+    "valid_from": "2024-01-01",
+    "valid_to": "2027-12-31",
+    "status": "valid",
+    "gtins": ["0884112345678", "0884112345685"],
+    "product_finder": "https://tcocertified.com/product/dell-latitude-7440",
+    "certificate_pdf": "https://tcocertified.com/certificates/DE125060063.pdf",
+    "product_page": "https://dell.com/latitude7440",
+    "attributes": {"recycled_content_pct": 40}
+  },
+  {
+    "certificate_number": "HP99887766",
+    "brand": "HP",
+    "model": "Z24n G3",
+    "category": "Displays",
+    "generation": "g10",
+    "valid_from": "2024-05-01",
+    "valid_to": "2026-04-30",
+    "status": "valid",
+    "gtins": ["0190012345678"],
+    "product_finder": "https://tcocertified.com/product/hp-z24n-g3",
+    "certificate_pdf": "https://tcocertified.com/certificates/HP99887766.pdf",
+    "product_page": "https://hp.com/z24n-g3",
+    "attributes": {"recycled_content_pct": 30}
+  },
+  {
+    "certificate_number": "LN12345678",
+    "brand": "Lenovo",
+    "model": "ThinkCentre Neo 50s",
+    "category": "Desktops",
+    "generation": "g10",
+    "valid_from": "2024-02-15",
+    "valid_to": "2027-02-14",
+    "status": "valid",
+    "gtins": ["0196112345678"],
+    "product_finder": "https://tcocertified.com/product/lenovo-neo50s",
+    "certificate_pdf": "https://tcocertified.com/certificates/LN12345678.pdf",
+    "product_page": "https://lenovo.com/neo50s",
+    "attributes": {"recycled_content_pct": 25}
+  }
+]

--- a/connectors/tco_certified/providers/__init__.py
+++ b/connectors/tco_certified/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Provider modules for the TCO Certified connector."""

--- a/connectors/tco_certified/providers/csv_loader.py
+++ b/connectors/tco_certified/providers/csv_loader.py
@@ -1,0 +1,110 @@
+"""Local CSV loader for TCO Certified certificates."""
+
+from __future__ import annotations
+
+import csv
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .. import adapter
+from ..adapter import UniversalCertificationV0
+
+_HEADERS = [
+    "certificate_number",
+    "brand",
+    "model",
+    "category",
+    "generation",
+    "valid_from",
+    "valid_to",
+    "status",
+    "gtins",
+    "product_finder",
+    "certificate_pdf",
+    "product_page",
+    "recycled_content_pct",
+]
+
+
+def _load_rows(path: str | None = None) -> List[Dict[str, str]]:
+    p = Path(path or os.getenv("CSV_PATH", ""))
+    if not p.exists():
+        raise FileNotFoundError("CSV file not found; set --path or CSV_PATH env")
+    rows: List[Dict[str, str]] = []
+    with p.open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def _row_to_item(row: Dict[str, str]) -> UniversalCertificationV0:
+    attrs: Dict[str, Any] = {}
+    if row.get("recycled_content_pct"):
+        try:
+            attrs["recycled_content_pct"] = float(row["recycled_content_pct"])
+        except ValueError:
+            attrs["recycled_content_pct"] = row["recycled_content_pct"]
+    return adapter.normalize(
+        {
+            "certificate_number": row.get("certificate_number"),
+            "brand": row.get("brand"),
+            "model": row.get("model"),
+            "category": row.get("category"),
+            "generation": row.get("generation"),
+            "valid_from": row.get("valid_from"),
+            "valid_to": row.get("valid_to"),
+            "status": row.get("status"),
+            "gtins": row.get("gtins"),
+            "product_finder": row.get("product_finder"),
+            "certificate_pdf": row.get("certificate_pdf"),
+            "product_page": row.get("product_page"),
+            "attributes": attrs,
+            "raw": row,
+            "source_url": None,
+        },
+        provider="csv",
+        source="tco:csv",
+    )
+
+
+def search(
+    q: str | None = None,
+    brand: str | None = None,
+    model: str | None = None,
+    category: str | None = None,
+    gtin: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    path: str | None = None,
+    **_: Any,
+) -> List[UniversalCertificationV0]:
+    rows = _load_rows(path)
+    matches: List[UniversalCertificationV0] = []
+    for row in rows:
+        hay = " ".join([row.get("brand", ""), row.get("model", ""), row.get("category", "")]).lower()
+        if q and q.lower() not in hay:
+            continue
+        if brand and brand.lower() not in row.get("brand", "").lower():
+            continue
+        if model and model.lower() not in row.get("model", "").lower():
+            continue
+        if category and category.lower() not in row.get("category", "").lower():
+            continue
+        if gtin and gtin not in adapter.listify_gtins(row.get("gtins")):
+            continue
+        matches.append(_row_to_item(row))
+    return matches[offset : offset + limit]
+
+
+def get_by_certificate(
+    certificate_number: str,
+    path: str | None = None,
+    **_: Any,
+) -> Optional[UniversalCertificationV0]:
+    rows = _load_rows(path)
+    for row in rows:
+        if str(row.get("certificate_number")) == certificate_number:
+            return _row_to_item(row)
+    return None

--- a/connectors/tco_certified/providers/gtin_api.py
+++ b/connectors/tco_certified/providers/gtin_api.py
@@ -1,0 +1,161 @@
+"""Provider for the experimental TCO Certified GTIN API.
+
+The API is opt-in and requires a base URL via ``TCO_GTIN_API_BASE``. When the
+base is missing, a fixture path can be supplied for offline tests. Networking is
+implemented via :mod:`urllib.request` with a tiny token-bucket throttle to stay
+polite.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .. import adapter
+from ..adapter import UniversalCertificationV0
+
+USER_AGENT = (
+    "circl-tco-gtin/0.1 "
+    "(+https://github.com/andremair97/circl-docs)"
+)
+
+__all__ = [
+    "TcoGtinHttpError",
+    "TcoGtinParseError",
+    "search",
+    "get_by_certificate",
+]
+
+
+class TcoGtinHttpError(Exception):
+    """Raised when the GTIN API returns an HTTP error or is unreachable."""
+
+
+class TcoGtinParseError(Exception):
+    """Raised when a response cannot be decoded as JSON."""
+
+
+_tokens: float = 0.0
+_last: float = time.monotonic()
+
+
+def _throttle() -> None:
+    global _tokens, _last
+    rate = float(os.getenv("TCO_GTIN_REQUESTS_PER_SEC", "4"))
+    capacity = max(rate, 1)
+    now = time.monotonic()
+    elapsed = now - _last
+    _tokens = min(capacity, _tokens + elapsed * rate)
+    if _tokens < 1:
+        wait = (1 - _tokens) / rate
+        time.sleep(wait + random.uniform(0, 0.1))
+        now = time.monotonic()
+        elapsed = now - _last
+        _tokens = min(capacity, _tokens + elapsed * rate)
+    _tokens -= 1
+    _last = now
+
+
+def _request(path: str) -> Dict[str, Any]:
+    base = os.getenv("TCO_GTIN_API_BASE")
+    if not base:
+        raise TcoGtinHttpError("TCO_GTIN_API_BASE not set")
+    url = base.rstrip("/") + "/" + path.lstrip("/")
+    _throttle()
+    headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+    token = os.getenv("TCO_GTIN_API_KEY")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    timeout = float(os.getenv("TCO_GTIN_TIMEOUT_SECONDS", "10"))
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = getattr(resp, "status", resp.getcode())
+            if status != 200:
+                raise TcoGtinHttpError(f"HTTP {status} for {url}")
+            raw = resp.read()
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure
+        raise TcoGtinHttpError(str(exc)) from exc
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise TcoGtinParseError(str(exc)) from exc
+    data["_source_url"] = url
+    return data
+
+
+def _from_fixture(path: Path) -> Dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+def _map_lookup(raw: Dict[str, Any]) -> Optional[UniversalCertificationV0]:
+    certificate = raw.get("certificate_number") or raw.get("certificate")
+    if not certificate and not raw.get("brand"):
+        return None
+    return adapter.normalize(
+        {
+            "certificate_number": certificate,
+            "brand": raw.get("brand"),
+            "model": raw.get("model"),
+            "category": raw.get("category"),
+            "generation": raw.get("generation"),
+            "valid_from": raw.get("valid_from"),
+            "valid_to": raw.get("valid_to"),
+            "status": raw.get("status"),
+            "gtins": raw.get("gtins") or [raw.get("gtin")],
+            "product_finder": raw.get("links", {}).get("product_finder"),
+            "certificate_pdf": raw.get("links", {}).get("certificate_pdf"),
+            "product_page": raw.get("links", {}).get("product_page"),
+            "attributes": raw.get("attributes", {}),
+            "source_url": raw.get("_source_url"),
+            "fetched_at": adapter.iso_now(),
+            "raw": raw,
+        },
+        provider="gtin-api",
+        source="tco:gtin-api",
+    )
+
+
+def search(
+    q: str | None = None,
+    brand: str | None = None,
+    model: str | None = None,
+    category: str | None = None,
+    gtin: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    path: str | None = None,
+    fixture_path: str | None = None,
+    **_: Any,
+) -> List[UniversalCertificationV0]:
+    """Search by GTIN. Other parameters are ignored for now."""
+
+    if not gtin:
+        return []
+    data: Dict[str, Any]
+    if fixture_path or (path and not os.getenv("TCO_GTIN_API_BASE")):
+        p = Path(fixture_path or path)
+        data = _from_fixture(p)
+    else:
+        encoded = urllib.parse.quote(gtin)
+        data = _request(f"lookup?gtin={encoded}")
+    item = _map_lookup(data)
+    return [item] if item else []
+
+
+def get_by_certificate(certificate_number: str, **_: Any) -> Optional[UniversalCertificationV0]:
+    """Lookup by certificate number if the API exposes it.
+
+    The pilot API currently focuses on GTIN lookups, so this helper returns
+    ``None`` to signal that the capability is unavailable.
+    """
+
+    return None

--- a/connectors/tco_certified/providers/productfinder_stub.py
+++ b/connectors/tco_certified/providers/productfinder_stub.py
@@ -1,0 +1,79 @@
+"""Fixture-only stub mimicking TCO Certified Product Finder exports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .. import adapter
+from ..adapter import UniversalCertificationV0
+
+_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures/productfinder_stub_inventory.json"
+
+
+def _load_inventory(path: str | None = None) -> List[Dict[str, Any]]:
+    p = Path(path) if path else _FIXTURE
+    text = p.read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+def _match(item: Dict[str, Any], q: str | None, brand: str | None, model: str | None, category: str | None, gtin: str | None) -> bool:
+    if q:
+        hay = " ".join([
+            item.get("brand", ""),
+            item.get("model", ""),
+            item.get("category", ""),
+        ]).lower()
+        if q.lower() not in hay:
+            return False
+    if brand and brand.lower() not in str(item.get("brand", "")).lower():
+        return False
+    if model and model.lower() not in str(item.get("model", "")).lower():
+        return False
+    if category and category.lower() not in str(item.get("category", "")).lower():
+        return False
+    if gtin and gtin not in adapter.listify_gtins(item.get("gtins")):
+        return False
+    return True
+
+
+def search(
+    q: str | None = None,
+    brand: str | None = None,
+    model: str | None = None,
+    category: str | None = None,
+    gtin: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    path: str | None = None,
+    **_: Any,
+) -> List[UniversalCertificationV0]:
+    inventory = _load_inventory(path)
+    matches: List[UniversalCertificationV0] = []
+    for raw in inventory:
+        if not _match(raw, q, brand, model, category, gtin):
+            continue
+        item = adapter.normalize(
+            raw | {"raw": raw, "source_url": "https://productfinder.tco"},
+            "productfinder-stub",
+            "tco:productfinder-stub",
+        )
+        matches.append(item)
+    return matches[offset : offset + limit]
+
+
+def get_by_certificate(
+    certificate_number: str,
+    path: str | None = None,
+    **_: Any,
+) -> Optional[UniversalCertificationV0]:
+    inventory = _load_inventory(path)
+    for raw in inventory:
+        if str(raw.get("certificate_number")) == certificate_number:
+            return adapter.normalize(
+                raw | {"raw": raw, "source_url": "https://productfinder.tco"},
+                "productfinder-stub",
+                "tco:productfinder-stub",
+            )
+    return None

--- a/docs/connectors/tco_certified.md
+++ b/docs/connectors/tco_certified.md
@@ -1,0 +1,60 @@
+# TCO Certified Connector
+
+The TCO Certified connector helps verify hardware certifications and exposes
+basic metadata about compliant products. It follows a provider architecture so
+each data source can evolve independently.
+
+## Providers
+
+- **GTIN API** – opt-in live lookup by GTIN. Requires an API base URL
+  (`TCO_GTIN_API_BASE`) and optionally an API key (`TCO_GTIN_API_KEY`).
+- **CSV loader** – reads local exports from the Product Finder. No network
+  access required.
+- **Product Finder stub** – small JSON fixture for offline development. Useful
+  for tests and demos when live access is unavailable.
+
+All providers normalise their output to a lightweight `UniversalCertificationV0`
+shape so downstream code has a consistent contract.
+
+## CLI examples
+
+```bash
+# Search via CSV
+python -m connectors.tco_certified.cli search --provider csv --q "Dell" \
+  --path connectors/tco_certified/fixtures/certificates_sample.csv
+
+# Search fixture stub
+python -m connectors.tco_certified.cli search --provider productfinder-stub --q display
+
+# GTIN lookup (requires API base and optional key)
+export TCO_GTIN_API_BASE="https://industry.tcocertified.com/gtin-api"
+export TCO_GTIN_API_KEY="..."
+python -m connectors.tco_certified.cli search --provider gtin-api --gtin 0887276789012
+```
+
+## Normalised output
+
+```json
+{
+  "source": "tco:csv",
+  "provider": "csv",
+  "id": "DE125060063",
+  "certificate_number": "DE125060063",
+  "brand": "Dell",
+  "model": "Latitude 7440",
+  "gtins": ["0884112345678", "0884112345685"],
+  "validity": {"valid_from": "2024-01-01", "valid_to": "2027-12-31", "status": "valid"},
+  "links": {
+    "product_finder": "https://tcocertified.com/product/dell-latitude-7440",
+    "certificate_pdf": "https://tcocertified.com/certificates/DE125060063.pdf"
+  }
+}
+```
+
+## Notes
+
+- The GTIN API is a pilot for resellers; access is not public.
+- Respect rate limits (`TCO_GTIN_REQUESTS_PER_SEC`) and timeouts
+  (`TCO_GTIN_TIMEOUT_SECONDS`). A custom User-Agent is sent by default.
+- The connector avoids scraping the TCO Certified website. Use official exports
+  or APIs only.

--- a/tests/connectors/test_tco_certified_live_gtin.py
+++ b/tests/connectors/test_tco_certified_live_gtin.py
@@ -1,0 +1,17 @@
+import os
+import pytest
+
+from connectors.tco_certified import client
+
+
+@pytest.mark.skipif(
+    os.getenv("TCO_LIVE_TEST") != "1" or not os.getenv("TCO_GTIN_API_BASE"),
+    reason="live GTIN test disabled",
+)
+def test_live_gtin_lookup():
+    gtin = os.getenv("TCO_GTIN_TEST_GTIN", "0887276789012")
+    items = client.search(provider="gtin-api", gtin=gtin, limit=1)
+    assert items, "GTIN lookup returned no items – check API access or GTIN"
+    item = items[0]
+    assert item["certificate_number"]
+    assert item["brand"] and item["model"]

--- a/tests/connectors/test_tco_certified_unit.py
+++ b/tests/connectors/test_tco_certified_unit.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from connectors.tco_certified import adapter, client
+from connectors.tco_certified.client import ProviderNotAvailableError
+
+FIXTURES = Path("connectors/tco_certified/fixtures")
+
+
+def load_json(name: str):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_productfinder_stub_search():
+    items = client.search(
+        provider="productfinder-stub",
+        q="display",
+        path=str(FIXTURES / "productfinder_stub_inventory.json"),
+    )
+    assert items and items[0]["provider"] == "productfinder-stub"
+    for item in items:
+        assert item["brand"] and item["model"]
+        assert "valid_from" in item["validity"]
+        assert item["provenance"]
+
+
+def test_csv_loader_multi_gtin_and_dates():
+    items = client.search(
+        provider="csv",
+        q="Dell",
+        path=str(FIXTURES / "certificates_sample.csv"),
+    )
+    assert items and len(items[0]["gtins"]) == 2
+    assert (item := items[0])
+    assert item["validity"]["valid_from"] == "2024-01-01"
+
+
+def test_gtin_api_fixture_search():
+    items = client.search(
+        provider="gtin-api",
+        gtin="0887276789012",
+        fixture_path=str(FIXTURES / "gtin_api_lookup.json"),
+    )
+    assert items and items[0]["certificate_number"] == "TC0X12345"
+
+
+def test_dispatcher_bad_provider():
+    with pytest.raises(ProviderNotAvailableError):
+        client.search(provider="unknown")
+
+
+def test_sanitize_raw_bounds_size():
+    raw = {"big": "x" * 40000, "arr": list(range(1000))}
+    cleaned = adapter.sanitize_raw(raw, max_bytes=100)
+    assert len(cleaned["big"]) <= 100
+    assert len(cleaned["arr"]) <= 20


### PR DESCRIPTION
## Summary
- add isolated TCO Certified connector with provider dispatcher, adapter, and JSONL CLI
- include GTIN API client (opt-in live), CSV loader, and Product Finder stub with fixtures
- document usage and provide offline and optional live tests

## Testing
- `python -m pytest tests/connectors/test_tco_certified_unit.py -q`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_68be0a30858c83218fe4849f3748dbe4