### PR TITLE
feat(connectors): add Fairtrade Product Finder

### DIFF
--- a/changelog/feat-connector-fairtrade-product_finder.md
+++ b/changelog/feat-connector-fairtrade-product_finder.md
@@ -1,0 +1,1 @@
+feat(connectors): add isolated Fairtrade Product Finder connector (UK/global fixtures + opt-in CSV provider); includes CLI, tests, docs

--- a/connectors/fairtrade_product_finder/README.md
+++ b/connectors/fairtrade_product_finder/README.md
@@ -1,0 +1,43 @@
+# Fairtrade Product Finder Connector
+
+This connector surfaces Fairtrade certified products and licensees. It ships with
+lightweight fixtures for the UK and global directories plus an optional CSV
+provider for "live" data sets. The modules are self-contained and do not pull in
+third‑party dependencies.
+
+## Providers
+
+| Provider | Description | Source |
+| --- | --- | --- |
+| `fixtures_uk` | Small sample of the UK product directory | `fixtures/uk_directory.json` |
+| `fixtures_global` | Sample of the international directory | `fixtures/global_directory.json` |
+| `csv` | Opt-in CSV export, loaded from env | `FAIRTRADE_CSV_PATH` or `FAIRTRADE_CSV_URL` |
+
+## Environment variables
+
+- `FAIRTRADE_CSV_PATH` — path to a CSV file.
+- `FAIRTRADE_CSV_URL` — HTTPS URL to fetch the CSV from.
+- `FAIRTRADE_TIMEOUT_SECONDS` — network timeout (default 10).
+- `FAIRTRADE_RPS` — requests per second throttle for remote CSV (default 3).
+
+## CSV header mapping
+
+| Header | Normalized field |
+| --- | --- |
+| `name` | `name` |
+| `brand` | `brand_owner.brand` |
+| `category` | `categories` |
+| `gtin` | `product_ids.gtins` |
+| `country` | `country_markets` |
+| `image_url` | `images` |
+| `page_url` | `url` |
+| `licensee` | `certification.licensee` |
+| `floid` | `certification.floid` |
+| `validity_from` | `certification.valid_from` |
+| `validity_to` | `certification.valid_to` |
+| `status` | `certification.status` |
+
+## Contributing fixtures
+
+Keep fixtures small and representative. Add new examples under
+`connectors/fairtrade_product_finder/fixtures/` and ensure tests still pass.

--- a/connectors/fairtrade_product_finder/__init__.py
+++ b/connectors/fairtrade_product_finder/__init__.py
@@ -1,0 +1,1 @@
+"""Fairtrade Product Finder connector package."""

--- a/connectors/fairtrade_product_finder/adapter.py
+++ b/connectors/fairtrade_product_finder/adapter.py
@@ -1,0 +1,100 @@
+"""Normalize Fairtrade Product Finder payloads to ``FairtradeProductV0``.
+
+The adapter keeps the schema self-contained so the connector has no cross-PR
+coupling. Helpers are intentionally small and conservative to avoid large
+provenance payloads.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from typing import Dict, List, Optional, TypedDict
+
+
+class Certification(TypedDict, total=False):
+    scheme: str
+    floid: Optional[str]
+    licensee: Optional[str]
+    status: Optional[str]
+    valid_from: Optional[str]
+    valid_to: Optional[str]
+    scope: Optional[str]
+
+
+class ProductId(TypedDict, total=False):
+    gtins: List[str]
+    sku: Optional[str]
+
+
+class Price(TypedDict, total=False):
+    value: Optional[float]
+    currency: Optional[str]
+    unit: Optional[str]
+
+
+class BrandOwner(TypedDict, total=False):
+    brand: Optional[str]
+    manufacturer: Optional[str]
+
+
+class Provenance(TypedDict, total=False):
+    source_url: Optional[str]
+    fetched_at: Optional[str]
+    raw: Dict
+
+
+class FairtradeProductV0(TypedDict, total=False):
+    source: str
+    provider: str
+    id: str
+    name: Optional[str]
+    brand_owner: BrandOwner
+    categories: List[str]
+    product_ids: ProductId
+    country_markets: List[str]
+    images: List[str]
+    url: Optional[str]
+    price: Price
+    certification: Certification
+    provenance: Provenance
+
+
+def iso_now() -> str:
+    """Return a UTC ISO8601 timestamp with ``Z`` suffix."""
+
+    return _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def _trim(value, max_items: int = 20, max_str: int = 1000):
+    """Recursively trim ``value`` to keep provenance bounded."""
+
+    if isinstance(value, list):
+        return [_trim(v, max_items, max_str) for v in value[:max_items]]
+    if isinstance(value, dict):
+        return {
+            k: _trim(v, max_items, max_str)
+            for k, v in list(value.items())[:max_items]
+        }
+    if isinstance(value, str) and len(value) > max_str:
+        return value[:max_str]
+    return value
+
+
+def sanitize_raw(raw: Dict, max_bytes: int = 30000) -> Dict:
+    """Truncate large structures so the JSON encoded size stays within ``max_bytes``.
+
+    The function does a best-effort trim; it never raises and returns a copy of
+    ``raw`` that is safe to JSON‑encode in provenance.
+    """
+
+    trimmed = _trim(raw)
+    encoded = json.dumps(trimmed, ensure_ascii=False)
+    if len(encoded.encode("utf-8")) <= max_bytes:
+        return trimmed
+    # If still too large, trim more aggressively.
+    trimmed = _trim(trimmed, max_items=10, max_str=200)
+    encoded = json.dumps(trimmed, ensure_ascii=False)
+    if len(encoded.encode("utf-8")) <= max_bytes:
+        return trimmed
+    return {}  # Fallback to empty if impossible to keep under the limit.

--- a/connectors/fairtrade_product_finder/cli.py
+++ b/connectors/fairtrade_product_finder/cli.py
@@ -1,0 +1,70 @@
+"""JSON Lines CLI for the Fairtrade Product Finder connector."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import List
+
+from . import client
+from .providers.csv_provider import CsvLoadError
+
+
+def _print(items: List[dict]) -> None:
+    for item in items:
+        print(json.dumps(item, ensure_ascii=False))
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Fairtrade Product Finder CLI")
+    sub = parser.add_subparsers(dest="cmd")
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--provider", required=True, choices=["fixtures_uk", "fixtures_global", "csv"])
+
+    p_search = sub.add_parser("search", parents=[common], help="search for products")
+    p_search.add_argument("--q", required=True)
+    p_search.add_argument("--brand")
+    p_search.add_argument("--country")
+    p_search.add_argument("--limit", type=int, default=20)
+    p_search.add_argument("--offset", type=int, default=0)
+
+    p_item = sub.add_parser("item", parents=[common], help="fetch product by id")
+    p_item.add_argument("--id", required=True)
+
+    p_gtin = sub.add_parser("gtin", parents=[common], help="lookup product by GTIN")
+    p_gtin.add_argument("--gtin", required=True)
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.cmd == "search":
+            items = client.search_products(
+                args.provider,
+                args.q,
+                brand=args.brand,
+                country=args.country,
+                limit=args.limit,
+                offset=args.offset,
+            )
+            _print(items)
+        elif args.cmd == "item":
+            item = client.get_product(args.provider, args.id)
+            if item:
+                _print([item])
+        elif args.cmd == "gtin":
+            item = client.lookup_by_gtin(args.provider, args.gtin)
+            if item:
+                _print([item])
+        else:
+            parser.print_help()
+            return 1
+    except (client.ProviderNotAvailableError, CsvLoadError) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/connectors/fairtrade_product_finder/client.py
+++ b/connectors/fairtrade_product_finder/client.py
@@ -1,0 +1,69 @@
+"""Provider dispatcher for the Fairtrade Product Finder connector."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .providers import csv_provider, fixtures_global, fixtures_uk
+
+__all__ = [
+    "ProviderNotAvailableError",
+    "search_products",
+    "get_product",
+    "lookup_by_gtin",
+]
+
+
+class ProviderNotAvailableError(Exception):
+    """Raised when a requested provider is not implemented."""
+
+
+_PROVIDERS = {
+    "fixtures_uk": fixtures_uk,
+    "fixtures_global": fixtures_global,
+    "csv": csv_provider,
+}
+
+
+def _get_provider(name: str):
+    try:
+        return _PROVIDERS[name]
+    except KeyError as exc:
+        raise ProviderNotAvailableError(name) from exc
+
+
+def search_products(
+    provider: str,
+    query: str,
+    *,
+    brand: str | None = None,
+    country: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs,
+) -> List[Dict]:
+    """Search products via ``provider`` and return ``List[FairtradeProductV0]``."""
+
+    module = _get_provider(provider)
+    return module.search_products(
+        query,
+        brand=brand,
+        country=country,
+        limit=limit,
+        offset=offset,
+        **kwargs,
+    )
+
+
+def get_product(provider: str, product_id: str, **kwargs) -> Dict | None:
+    """Fetch a product by ``product_id`` from ``provider``."""
+
+    module = _get_provider(provider)
+    return module.get_product(product_id, **kwargs)
+
+
+def lookup_by_gtin(provider: str, gtin: str, **kwargs) -> Dict | None:
+    """Return the first product matching ``gtin`` from ``provider``."""
+
+    module = _get_provider(provider)
+    return module.lookup_by_gtin(gtin, **kwargs)

--- a/connectors/fairtrade_product_finder/fixtures/global_directory.json
+++ b/connectors/fairtrade_product_finder/fixtures/global_directory.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "GLOBAL-001",
+    "name": "Global Coffee Blend",
+    "brand": "Global Brew",
+    "manufacturer": "Global Brew AG",
+    "category": "coffee",
+    "gtins": ["4012345678901"],
+    "country_markets": ["DE", "AT"],
+    "image": "https://example.org/global-coffee.jpg",
+    "url": "https://example.org/global-coffee",
+    "licensee": "Global Brew AG",
+    "floid": "FLO123456",
+    "valid_from": "2023-01-15",
+    "valid_to": "2024-01-15",
+    "status": "valid"
+  },
+  {
+    "id": "GLOBAL-002",
+    "name": "World Tea Selection",
+    "brand": "World Tea",
+    "manufacturer": "World Tea GmbH",
+    "category": "tea",
+    "gtins": ["4098765432105"],
+    "country_markets": ["DE", "NL", "FR"],
+    "image": "https://example.org/world-tea.jpg",
+    "url": "https://example.org/world-tea",
+    "licensee": "World Tea GmbH",
+    "floid": "FLO654321",
+    "valid_from": "2022-05-01",
+    "valid_to": "2025-05-01",
+    "status": "valid"
+  },
+  {
+    "id": "GLOBAL-003",
+    "name": "International Cocoa Powder",
+    "brand": "Cocoa World",
+    "manufacturer": "Cocoa World BV",
+    "category": "chocolate",
+    "gtins": ["4001234567002"],
+    "country_markets": ["FR", "BE"],
+    "image": "https://example.org/cocoa.jpg",
+    "url": "https://example.org/cocoa",
+    "licensee": "Cocoa World BV",
+    "floid": "FLO777888",
+    "valid_from": "2023-02-01",
+    "valid_to": "2024-02-01",
+    "status": "valid"
+  }
+]

--- a/connectors/fairtrade_product_finder/fixtures/sample_catalog.csv
+++ b/connectors/fairtrade_product_finder/fixtures/sample_catalog.csv
@@ -1,0 +1,3 @@
+name,brand,category,gtin,country,image_url,page_url,licensee,floid,validity_from,validity_to,status
+Sample Coffee,Sample Brand,coffee,5098765432100,UK,https://example.org/sample-coffee.jpg,https://example.org/sample-coffee,Sample Co,FLO999999,2023-01-01,2024-01-01,valid
+Sample Tea,Another Brand,tea,5000000000002,DE;AT,https://example.org/sample-tea.jpg,https://example.org/sample-tea,Tea Co,FLO888888,2022-05-05,2023-05-05,expired

--- a/connectors/fairtrade_product_finder/fixtures/uk_directory.json
+++ b/connectors/fairtrade_product_finder/fixtures/uk_directory.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "UK-FT-0001",
+    "name": "Fair Brew Coffee Beans",
+    "brand": "Fair Brew",
+    "manufacturer": "Fair Brew Ltd",
+    "category": "coffee",
+    "gtins": ["5012345678900"],
+    "country_markets": ["UK"],
+    "image": "https://example.org/coffee.jpg",
+    "url": "https://example.org/coffee",
+    "licensee": "Fair Brew Ltd",
+    "floid": "UK123",
+    "valid_from": "2023-01-01",
+    "valid_to": "2024-12-31",
+    "status": "valid"
+  },
+  {
+    "id": "UK-FT-0002",
+    "name": "Clipper Green Tea",
+    "brand": "Clipper",
+    "manufacturer": "Clipper Teas",
+    "category": "tea",
+    "gtins": ["5021991936450"],
+    "country_markets": ["UK"],
+    "image": "https://example.org/tea.jpg",
+    "url": "https://example.org/tea",
+    "licensee": "Clipper Teas",
+    "floid": "UK124",
+    "valid_from": "2022-06-01",
+    "valid_to": "2025-06-01",
+    "status": "valid"
+  },
+  {
+    "id": "UK-FT-0003",
+    "name": "Divine Chocolate Bar",
+    "brand": "Divine",
+    "manufacturer": "Divine Chocolate Ltd",
+    "category": "chocolate",
+    "gtins": ["5071234567890"],
+    "country_markets": ["UK"],
+    "image": "https://example.org/chocolate.jpg",
+    "url": "https://example.org/chocolate",
+    "licensee": "Divine Chocolate Ltd",
+    "floid": "UK125",
+    "valid_from": "2023-03-01",
+    "valid_to": "2024-03-01",
+    "status": "valid"
+  }
+]

--- a/connectors/fairtrade_product_finder/providers/__init__.py
+++ b/connectors/fairtrade_product_finder/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Provider implementations for the Fairtrade Product Finder connector."""

--- a/connectors/fairtrade_product_finder/providers/csv_provider.py
+++ b/connectors/fairtrade_product_finder/providers/csv_provider.py
@@ -1,0 +1,174 @@
+"""CSV provider for the Fairtrade Product Finder connector."""
+
+from __future__ import annotations
+
+import csv
+import os
+import random
+import shutil
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+from .. import adapter
+
+__all__ = ["CsvLoadError", "search_products", "get_product", "lookup_by_gtin"]
+
+USER_AGENT = (
+    "circl-fairtrade-csv/0.1 "
+    "(+https://github.com/andremair97/circl-docs)"
+)
+
+
+class CsvLoadError(Exception):
+    """Raised when the CSV source cannot be loaded."""
+
+
+_tokens: float = 0.0
+_last: float = time.monotonic()
+
+
+def _throttle() -> None:
+    rate = float(os.getenv("FAIRTRADE_RPS", "3"))
+    capacity = max(rate, 1)
+    global _tokens, _last
+    now = time.monotonic()
+    _tokens = min(capacity, _tokens + (now - _last) * rate)
+    if _tokens < 1:
+        wait = (1 - _tokens) / rate
+        time.sleep(wait + random.uniform(0, 0.1))
+        now = time.monotonic()
+        _tokens = min(capacity, _tokens + (now - _last) * rate)
+    _tokens -= 1
+    _last = now
+
+
+def _fetch_url(url: str) -> Path:
+    _throttle()
+    headers = {"User-Agent": USER_AGENT, "Accept": "text/csv, */*"}
+    req = urllib.request.Request(url, headers=headers)
+    timeout = float(os.getenv("FAIRTRADE_TIMEOUT_SECONDS", "10"))
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            tmp = tempfile.NamedTemporaryFile(delete=False)
+            with tmp:
+                shutil.copyfileobj(resp, tmp)
+            return Path(tmp.name)
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure
+        raise CsvLoadError(str(exc)) from exc
+
+
+_DATA: List[Dict] | None = None
+_SOURCE: str | None = None
+
+
+def _load_data() -> None:
+    global _DATA, _SOURCE
+    if _DATA is not None:
+        return
+    path = os.getenv("FAIRTRADE_CSV_PATH")
+    url = os.getenv("FAIRTRADE_CSV_URL")
+    if path:
+        csv_path = Path(path)
+    elif url:
+        csv_path = _fetch_url(url)
+    else:
+        raise CsvLoadError("FAIRTRADE_CSV_URL or FAIRTRADE_CSV_PATH must be set")
+    _SOURCE = url if url else Path(path).resolve().as_uri()
+    try:
+        with csv_path.open(newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            _DATA = list(reader)
+    except OSError as exc:
+        raise CsvLoadError(str(exc)) from exc
+    finally:
+        if url and csv_path.exists():
+            csv_path.unlink(missing_ok=True)
+
+
+def _normalize(row: Dict, idx: int) -> adapter.FairtradeProductV0:
+    gtin = row.get("gtin") or ""
+    countries: List[str] = []
+    country_field = row.get("country") or ""
+    for part in country_field.replace(";", ",").split(","):
+        part = part.strip()
+        if part:
+            countries.append(part)
+    images = [row.get("image_url")] if row.get("image_url") else []
+    item_id = row.get("id") or gtin or f"row{idx}"
+    return {
+        "source": "fairtrade:csv",
+        "provider": "csv",
+        "id": item_id,
+        "name": row.get("name"),
+        "brand_owner": {"brand": row.get("brand")},
+        "categories": [row.get("category")] if row.get("category") else [],
+        "product_ids": {"gtins": [gtin] if gtin else []},
+        "country_markets": countries,
+        "images": images,
+        "url": row.get("page_url"),
+        "price": {},
+        "certification": {
+            "scheme": "Fairtrade",
+            "floid": row.get("floid"),
+            "licensee": row.get("licensee"),
+            "status": row.get("status"),
+            "valid_from": row.get("validity_from"),
+            "valid_to": row.get("validity_to"),
+        },
+        "provenance": {
+            "source_url": _SOURCE,
+            "fetched_at": adapter.iso_now(),
+            "raw": adapter.sanitize_raw(row),
+        },
+    }
+
+
+def search_products(
+    query: str,
+    *,
+    brand: str | None = None,
+    country: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs,
+) -> List[adapter.FairtradeProductV0]:
+    _load_data()
+    q = query.lower()
+    results: List[adapter.FairtradeProductV0] = []
+    assert _DATA is not None
+    for idx, row in enumerate(_DATA):
+        name = (row.get("name") or "").lower()
+        category = (row.get("category") or "").lower()
+        row_brand = (row.get("brand") or "").lower()
+        countries = (row.get("country") or "").lower()
+        if q not in name and q not in category and q not in row_brand:
+            continue
+        if brand and row_brand != brand.lower():
+            continue
+        if country and country.lower() not in countries:
+            continue
+        results.append(_normalize(row, idx))
+    return results[offset : offset + limit]
+
+
+def get_product(product_id: str, **kwargs) -> adapter.FairtradeProductV0 | None:
+    _load_data()
+    assert _DATA is not None
+    for idx, row in enumerate(_DATA):
+        item = _normalize(row, idx)
+        if item["id"] == product_id:
+            return item
+    return None
+
+
+def lookup_by_gtin(gtin: str, **kwargs) -> adapter.FairtradeProductV0 | None:
+    _load_data()
+    assert _DATA is not None
+    for idx, row in enumerate(_DATA):
+        if row.get("gtin") == gtin:
+            return _normalize(row, idx)
+    return None

--- a/connectors/fairtrade_product_finder/providers/fixtures_global.py
+++ b/connectors/fairtrade_product_finder/providers/fixtures_global.py
@@ -1,0 +1,91 @@
+"""Fixture provider for the Fairtrade Product Finder (global directory)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from .. import adapter
+
+_SOURCE_URL = "https://www.fairtrade.net/products"
+_FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "global_directory.json"
+
+with _FIXTURES.open("r", encoding="utf-8") as fh:
+    _DATA: List[Dict] = json.load(fh)
+
+
+def _normalize(entry: Dict) -> adapter.FairtradeProductV0:
+    return {
+        "source": "fairtrade:global-fixtures",
+        "provider": "fixtures_global",
+        "id": entry.get("id", ""),
+        "name": entry.get("name"),
+        "brand_owner": {
+            "brand": entry.get("brand"),
+            "manufacturer": entry.get("manufacturer"),
+        },
+        "categories": [entry.get("category")] if entry.get("category") else [],
+        "product_ids": {
+            "gtins": entry.get("gtins", []),
+            "sku": entry.get("sku"),
+        },
+        "country_markets": entry.get("country_markets", []),
+        "images": [entry.get("image")] if entry.get("image") else [],
+        "url": entry.get("url"),
+        "price": {},
+        "certification": {
+            "scheme": "Fairtrade",
+            "floid": entry.get("floid"),
+            "licensee": entry.get("licensee"),
+            "status": entry.get("status"),
+            "valid_from": entry.get("valid_from"),
+            "valid_to": entry.get("valid_to"),
+            "scope": "International",
+        },
+        "provenance": {
+            "source_url": _SOURCE_URL,
+            "fetched_at": adapter.iso_now(),
+            "raw": adapter.sanitize_raw(entry),
+        },
+    }
+
+
+def search_products(
+    query: str,
+    *,
+    brand: str | None = None,
+    country: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs,
+) -> List[adapter.FairtradeProductV0]:
+    q = query.lower()
+    results: List[adapter.FairtradeProductV0] = []
+    for entry in _DATA:
+        name = (entry.get("name") or "").lower()
+        category = (entry.get("category") or "").lower()
+        entry_brand = (entry.get("brand") or "").lower()
+        countries = entry.get("country_markets", [])
+        if q not in name and q not in category and q not in entry_brand:
+            continue
+        if brand and entry_brand != brand.lower():
+            continue
+        if country and country not in countries:
+            continue
+        results.append(_normalize(entry))
+    return results[offset : offset + limit]
+
+
+def get_product(product_id: str, **kwargs) -> adapter.FairtradeProductV0 | None:
+    for entry in _DATA:
+        if entry.get("id") == product_id:
+            return _normalize(entry)
+    return None
+
+
+def lookup_by_gtin(gtin: str, **kwargs) -> adapter.FairtradeProductV0 | None:
+    for entry in _DATA:
+        if gtin in entry.get("gtins", []):
+            return _normalize(entry)
+    return None

--- a/connectors/fairtrade_product_finder/providers/fixtures_uk.py
+++ b/connectors/fairtrade_product_finder/providers/fixtures_uk.py
@@ -1,0 +1,91 @@
+"""Fixture provider for the Fairtrade Product Finder (UK directory)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from .. import adapter
+
+_SOURCE_URL = "https://www.fairtrade.org.uk/products/"
+_FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "uk_directory.json"
+
+with _FIXTURES.open("r", encoding="utf-8") as fh:
+    _DATA: List[Dict] = json.load(fh)
+
+
+def _normalize(entry: Dict) -> adapter.FairtradeProductV0:
+    return {
+        "source": "fairtrade:uk-fixtures",
+        "provider": "fixtures_uk",
+        "id": entry.get("id", ""),
+        "name": entry.get("name"),
+        "brand_owner": {
+            "brand": entry.get("brand"),
+            "manufacturer": entry.get("manufacturer"),
+        },
+        "categories": [entry.get("category")] if entry.get("category") else [],
+        "product_ids": {
+            "gtins": entry.get("gtins", []),
+            "sku": entry.get("sku"),
+        },
+        "country_markets": entry.get("country_markets", ["UK"]),
+        "images": [entry.get("image")] if entry.get("image") else [],
+        "url": entry.get("url"),
+        "price": {},
+        "certification": {
+            "scheme": "Fairtrade",
+            "floid": entry.get("floid"),
+            "licensee": entry.get("licensee"),
+            "status": entry.get("status"),
+            "valid_from": entry.get("valid_from"),
+            "valid_to": entry.get("valid_to"),
+            "scope": "UK",
+        },
+        "provenance": {
+            "source_url": _SOURCE_URL,
+            "fetched_at": adapter.iso_now(),
+            "raw": adapter.sanitize_raw(entry),
+        },
+    }
+
+
+def search_products(
+    query: str,
+    *,
+    brand: str | None = None,
+    country: str | None = "UK",
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs,
+) -> List[adapter.FairtradeProductV0]:
+    q = query.lower()
+    results: List[adapter.FairtradeProductV0] = []
+    for entry in _DATA:
+        name = (entry.get("name") or "").lower()
+        category = (entry.get("category") or "").lower()
+        entry_brand = (entry.get("brand") or "").lower()
+        countries = entry.get("country_markets", [])
+        if q not in name and q not in category and q not in entry_brand:
+            continue
+        if brand and entry_brand != brand.lower():
+            continue
+        if country and country not in countries:
+            continue
+        results.append(_normalize(entry))
+    return results[offset : offset + limit]
+
+
+def get_product(product_id: str, **kwargs) -> adapter.FairtradeProductV0 | None:
+    for entry in _DATA:
+        if entry.get("id") == product_id:
+            return _normalize(entry)
+    return None
+
+
+def lookup_by_gtin(gtin: str, **kwargs) -> adapter.FairtradeProductV0 | None:
+    for entry in _DATA:
+        if gtin in entry.get("gtins", []):
+            return _normalize(entry)
+    return None

--- a/docs/connectors/fairtrade_product_finder.md
+++ b/docs/connectors/fairtrade_product_finder.md
@@ -1,0 +1,47 @@
+# Fairtrade Product Finder Connector
+
+The Fairtrade Product Finder connector returns Fairtrade-certified products and
+licensees in a normalized shape. Official directories exist — the [Fairtrade
+Finder](https://www.fairtrade.org.uk/products/) and [FLOCERT customer search](https://www.flocert.net/solutions/fairtrade-services/customer-search/) — but
+they do not expose public JSON APIs. This module therefore ships with fixture
+providers and an opt-in CSV provider for maintainers who can supply exports.
+
+## Usage
+
+### CLI
+
+```bash
+python -m connectors.fairtrade_product_finder.cli search --provider fixtures_uk --q "coffee" --limit 5
+python -m connectors.fairtrade_product_finder.cli search --provider csv --q "tea" --brand "Clipper" --country "UK"
+python -m connectors.fairtrade_product_finder.cli item --provider fixtures_uk --id "UK-FT-0001"
+python -m connectors.fairtrade_product_finder.cli gtin --provider csv --gtin 5051234567890
+```
+
+Each command prints JSON Lines of normalized ``FairtradeProductV0`` items.
+
+## Normalized output
+
+```json
+{
+  "source": "fairtrade:uk-fixtures",
+  "provider": "fixtures_uk",
+  "id": "UK-FT-0001",
+  "name": "Fair Brew Coffee Beans",
+  "brand_owner": {"brand": "Fair Brew", "manufacturer": "Fair Brew Ltd"},
+  "categories": ["coffee"],
+  "product_ids": {"gtins": ["5012345678900"]},
+  "country_markets": ["UK"],
+  "images": ["https://example.org/coffee.jpg"],
+  "url": "https://example.org/coffee",
+  "price": {},
+  "certification": {"scheme": "Fairtrade", "scope": "UK"},
+  "provenance": {"source_url": "https://www.fairtrade.org.uk/products/"}
+}
+```
+
+## Notes
+
+- Fixture providers keep data sets tiny for offline tests.
+- The CSV provider performs polite throttling and sets a custom User-Agent.
+- Live CSV tests are gated by ``FT_LIVE_TEST`` and require ``FAIRTRADE_CSV_URL``
+  or ``FAIRTRADE_CSV_PATH``.

--- a/tests/connectors/test_fairtrade_product_finder_live_csv.py
+++ b/tests/connectors/test_fairtrade_product_finder_live_csv.py
@@ -1,0 +1,20 @@
+import os
+
+import pytest
+
+from connectors.fairtrade_product_finder import client
+
+
+live = os.getenv("FT_LIVE_TEST") == "1" and (
+    os.getenv("FAIRTRADE_CSV_URL") or os.getenv("FAIRTRADE_CSV_PATH")
+)
+
+
+@pytest.mark.skipif(not live, reason="FT_LIVE_TEST not enabled")
+def test_csv_search_smoke():
+    results = client.search_products("csv", "coffee", limit=2)
+    assert results
+    item = results[0]
+    assert item.get("id")
+    assert item.get("name")
+    assert isinstance(item.get("product_ids", {}).get("gtins", []), list)

--- a/tests/connectors/test_fairtrade_product_finder_unit.py
+++ b/tests/connectors/test_fairtrade_product_finder_unit.py
@@ -1,0 +1,39 @@
+import json
+
+import pytest
+
+from connectors.fairtrade_product_finder import adapter, client
+
+
+def _required_keys(item):
+    for key in ["source", "provider", "id", "name", "product_ids", "certification", "provenance"]:
+        assert key in item
+
+
+def test_fixture_uk_search_returns_items():
+    results = client.search_products("fixtures_uk", "coffee")
+    assert results
+    _required_keys(results[0])
+
+
+def test_fixture_global_search_returns_items():
+    results = client.search_products("fixtures_global", "tea")
+    assert results
+    _required_keys(results[0])
+
+
+def test_sanitize_raw_bounds_size():
+    raw = {"big": "x" * 5000}
+    cleaned = adapter.sanitize_raw(raw, max_bytes=1000)
+    assert len(json.dumps(cleaned)) <= 1000
+
+
+def test_dispatcher_rejects_bad_provider():
+    with pytest.raises(client.ProviderNotAvailableError):
+        client.search_products("missing", "coffee")
+
+
+def test_lookup_by_gtin():
+    item = client.lookup_by_gtin("fixtures_uk", "5071234567890")
+    assert item is not None
+    assert item["name"] == "Divine Chocolate Bar"


### PR DESCRIPTION
## Summary
- add Fairtrade Product Finder connector with UK & global fixtures
- support optional CSV provider and tiny JSONL CLI
- document usage and provide unit tests

## Testing
- `PYTHONPATH=. pytest tests/connectors/test_fairtrade_product_finder_unit.py -q`
- `PYTHONPATH=. pytest tests/connectors/test_fairtrade_product_finder_live_csv.py -q`
- `mkdocs build --strict >/tmp/mkdocs.log && tail -n 20 /tmp/mkdocs.log`


------
https://chatgpt.com/codex/tasks/task_e_68be09fe48f4832186d1d112a0b91549