### PR TITLE
feat(connectors): add ENERGY STAR connector

### DIFF
--- a/changelog/feat-connector-energystar.md
+++ b/changelog/feat-connector-energystar.md
@@ -1,0 +1,1 @@
+feat(connectors): add isolated ENERGY STAR connector (Socrata provider + CLI, offline tests & docs); no UI wiring

--- a/connectors/energystar/README.md
+++ b/connectors/energystar/README.md
@@ -1,0 +1,40 @@
+# ENERGY STAR Connector
+
+Offline-friendly connector for ENERGY STAR certified products served via the
+public [Socrata](https://data.energystar.gov) API. The module is self-contained
+and stdlib-only.
+
+## Environment Variables
+
+| Name | Description | Default |
+| --- | --- | --- |
+| `ENERGY_STAR_APP_TOKEN` | Optional API token for higher rate limits | _none_ |
+| `ENERGY_STAR_TIMEOUT_SECONDS` | HTTP timeout in seconds | `10` |
+| `ENERGY_STAR_RPS` | Requests per second throttle | `4` |
+| `ENERGY_STAR_BASE` | Base URL for the API | `https://data.energystar.gov` |
+
+## Categories
+
+| Key | Dataset ID | Human Name |
+| --- | --- | --- |
+| televisions | pd96-rr3d | ENERGY STAR Certified Televisions |
+| computers | j7nq-iepp | ENERGY STAR Certified Computers |
+| dehumidifiers | mgiu-hu4z | ENERGY STAR Certified Dehumidifiers |
+| heat_pumps | w7cv-9xjt | ENERGY STAR Certified Air-Source Heat Pumps |
+
+## CLI Examples
+
+```bash
+python -m connectors.energystar.cli search --category televisions --q "Samsung" --limit 5
+python -m connectors.energystar.cli item --category televisions --id "TV123"
+```
+
+## Adding Categories
+
+1. Extend the registry in `client.py` with the dataset id and human name.
+2. Add fixtures under `fixtures/` and corresponding unit tests.
+3. Keep requests polite: respect throttle env vars and provide a meaningful
+   User-Agent.
+
+ENERGY STAR is a registered trademark of the U.S. Environmental Protection
+Agency. Use of the mark or logo may require permission.

--- a/connectors/energystar/__init__.py
+++ b/connectors/energystar/__init__.py
@@ -1,0 +1,1 @@
+"""ENERGY STAR connector package."""

--- a/connectors/energystar/adapter.py
+++ b/connectors/energystar/adapter.py
@@ -1,0 +1,231 @@
+"""Normalize ENERGY STAR Socrata rows to ``UniversalEnergyProductV0``."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from typing import Any, Dict, List, Optional, TypedDict
+
+
+class Identifiers(TypedDict, total=False):
+    esuid: Optional[str]
+    model_number: Optional[str]
+    upcs: List[str]
+    sku: Optional[str]
+
+
+class Links(TypedDict, total=False):
+    product_page: Optional[str]
+    dataset_url: Optional[str]
+    image: Optional[str]
+    spec_sheet: Optional[str]
+
+
+class Metrics(TypedDict, total=False):
+    annual_kwh: Optional[float]
+    capacity: Optional[str]
+    efficiency: Optional[str]
+    other: Dict[str, Any]
+
+
+class UniversalEnergyProductV0(TypedDict, total=False):
+    source: str
+    provider: str
+    category: str
+    id: str
+    title: Optional[str]
+    brand: Optional[str]
+    model: Optional[str]
+    product_type: Optional[str]
+    identifiers: Identifiers
+    labels: List[str]
+    links: Links
+    metrics: Metrics
+    dates: Dict[str, Optional[str]]
+    provenance: Dict[str, Any]
+
+
+def iso_now() -> str:
+    """Return current UTC time in ISO8601 format."""
+
+    return _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def sanitize_raw(raw: Dict[str, Any], max_bytes: int = 30000) -> Dict[str, Any]:
+    """Trim large structures while keeping shape for provenance."""
+
+    def _trim(value: Any) -> Any:
+        if isinstance(value, dict):
+            out: Dict[str, Any] = {}
+            for k, v in value.items():
+                out[k] = _trim(v)
+                if len(json.dumps(out)) > max_bytes:
+                    del out[k]
+                    break
+            return out
+        if isinstance(value, list):
+            out_list = []
+            for v in value:
+                out_list.append(_trim(v))
+                if len(json.dumps(out_list)) > max_bytes:
+                    out_list.pop()
+                    break
+            return out_list
+        if isinstance(value, str):
+            enc = value.encode("utf-8")
+            if len(enc) > max_bytes:
+                enc = enc[:max_bytes]
+                return enc.decode("utf-8", "ignore")
+        return value
+    return _trim(raw)
+
+
+def _string(value: Any) -> Optional[str]:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _float(value: Any) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _list(value: Any) -> List[str]:
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    if isinstance(value, str):
+        return [v.strip() for v in value.split(",") if v.strip()]
+    return []
+
+
+def normalize_item(
+    category: str,
+    dataset_id: str,
+    dataset_url: str,
+    row: Dict[str, Any],
+    source_url: str,
+) -> UniversalEnergyProductV0:
+    """Map a single Socrata row to ``UniversalEnergyProductV0``."""
+
+    brand = _string(
+        row.get("brand_name")
+        or row.get("brand")
+        or row.get("manufacturer")
+        or row.get("brandname")
+    )
+    model = _string(row.get("model_number") or row.get("model") or row.get("model_name"))
+    product_type = _string(
+        row.get("product_type")
+        or row.get("product_types")
+        or row.get("computer_type")
+        or row.get("category")
+        or row.get("type")
+    )
+
+    esuid = _string(row.get("esuid") or row.get("es_uid") or row.get("es_unique_id"))
+    row_id = _string(row.get(":id") or row.get("_id") or row.get("id"))
+    item_id = esuid or f"{dataset_id}:{row_id}" if row_id else dataset_id
+
+    title_parts = [p for p in [brand, model] if p]
+    title = " ".join(title_parts) if title_parts else _string(row.get("model_name"))
+
+    identifiers: Identifiers = {
+        "esuid": esuid,
+        "model_number": model,
+        "upcs": _list(row.get("upc") or row.get("upcs") or row.get("upc_code")),
+    }
+    sku = _string(row.get("sku") or row.get("sku_number"))
+    if sku:
+        identifiers["sku"] = sku
+
+    labels: List[str] = ["ENERGY STAR"]
+    most = row.get("most_efficient") or row.get("meets_most_efficient")
+    if isinstance(most, str) and most.strip():
+        label = most if most.lower().startswith("most") else f"Most Efficient {most}".strip()
+        labels.append(label)
+    elif most:
+        labels.append("Most Efficient")
+
+    links: Links = {
+        "product_page": _string(
+            row.get("product_url") or row.get("product_page") or row.get("url")
+        ),
+        "dataset_url": dataset_url,
+        "image": _string(row.get("image_url") or row.get("image")),
+        "spec_sheet": _string(row.get("spec_sheet") or row.get("spec_sheet_url")),
+    }
+
+    annual_kwh = _float(
+        row.get("annual_energy_use_kwh")
+        or row.get("annual_kwh")
+        or row.get("annual_energy")
+        or row.get("kwh_year")
+    )
+    capacity = _string(
+        row.get("capacity")
+        or row.get("size_class")
+        or row.get("capacity_pints_per_day")
+        or row.get("cooling_capacity_btu_hr")
+    )
+    efficiency = _string(
+        row.get("ceer")
+        or row.get("uef")
+        or row.get("hspf2")
+        or row.get("hspf")
+        or row.get("seer2")
+        or row.get("seer")
+    )
+    other: Dict[str, Any] = {}
+    for key in [
+        "ceer",
+        "uef",
+        "hspf2",
+        "hspf",
+        "seer2",
+        "seer",
+        "cooling_capacity_btu_hr",
+        "capacity_pints_per_day",
+    ]:
+        if key in row:
+            other[key] = row[key]
+    metrics: Metrics = {
+        "annual_kwh": annual_kwh,
+        "capacity": capacity,
+        "efficiency": efficiency,
+        "other": other,
+    }
+
+    dates = {
+        "labeled": _string(
+            row.get("date_available_on_market")
+            or row.get("effective_date")
+            or row.get("availability_date")
+        ),
+        "updated": _string(row.get("updated") or row.get("date_last_modified") or row.get(":updated_at")),
+    }
+
+    return {
+        "source": "energystar:socrata",
+        "provider": "socrata",
+        "category": category,
+        "id": item_id,
+        "title": title,
+        "brand": brand,
+        "model": model,
+        "product_type": product_type,
+        "identifiers": identifiers,
+        "labels": labels,
+        "links": links,
+        "metrics": metrics,
+        "dates": dates,
+        "provenance": {
+            "source_url": source_url,
+            "fetched_at": iso_now(),
+            "raw": sanitize_raw(row),
+        },
+    }

--- a/connectors/energystar/cli.py
+++ b/connectors/energystar/cli.py
@@ -1,0 +1,60 @@
+"""JSON Lines CLI for the ENERGY STAR connector."""
+
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import List
+
+from . import client
+from .providers import socrata
+
+
+def _print(items: List[dict]) -> None:
+    for item in items:
+        print(json.dumps(item, ensure_ascii=False))
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="ENERGY STAR connector CLI")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_search = sub.add_parser("search", help="search within a category")
+    p_search.add_argument("--category", required=True, choices=client.CATEGORIES)
+    p_search.add_argument("--q")
+    p_search.add_argument("--limit", type=int, default=5)
+    p_search.add_argument("--offset", type=int, default=0)
+
+    p_item = sub.add_parser("item", help="fetch a single item")
+    p_item.add_argument("--category", required=True, choices=client.CATEGORIES)
+    p_item.add_argument("--id", required=True)
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.cmd == "search":
+            items = client.search_items(
+                args.category, q=args.q, limit=args.limit, offset=args.offset
+            )
+            _print(items)
+        elif args.cmd == "item":
+            item = client.get_item(args.category, args.id)
+            if item:
+                _print([item])
+        else:
+            parser.print_help()
+            return 1
+    except (
+        client.CategoryNotSupportedError,
+        socrata.SocrataHttpError,
+        socrata.SocrataParseError,
+    ) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/connectors/energystar/client.py
+++ b/connectors/energystar/client.py
@@ -1,0 +1,85 @@
+"""Provider dispatcher and category registry for ENERGY STAR."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+from .providers import socrata
+
+__all__ = [
+    "CategoryNotSupportedError",
+    "CATEGORIES",
+    "search_items",
+    "get_item",
+]
+
+
+class CategoryNotSupportedError(Exception):
+    """Raised when a requested category is not in the registry."""
+
+
+_REGISTRY: Dict[str, Dict[str, str]] = {
+    "televisions": {
+        "dataset_id": "pd96-rr3d",
+        "name": "ENERGY STAR Certified Televisions",
+    },
+    "computers": {
+        "dataset_id": "j7nq-iepp",
+        "name": "ENERGY STAR Certified Computers",
+    },
+    "dehumidifiers": {
+        "dataset_id": "mgiu-hu4z",
+        "name": "ENERGY STAR Certified Dehumidifiers",
+    },
+    "heat_pumps": {
+        "dataset_id": "w7cv-9xjt",
+        "name": "ENERGY STAR Certified Air-Source Heat Pumps",
+    },
+}
+
+CATEGORIES = sorted(_REGISTRY)
+
+
+def _category_info(category: str) -> Dict[str, str]:
+    try:
+        info = _REGISTRY[category]
+    except KeyError:  # pragma: no cover - exercised in unit tests
+        raise CategoryNotSupportedError(category)
+    base = os.getenv("ENERGY_STAR_BASE", "https://data.energystar.gov")
+    dataset_url = f"{base}/d/{info['dataset_id']}"
+    return {**info, "dataset_url": dataset_url}
+
+
+def search_items(
+    category: str,
+    q: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs,
+) -> list[dict]:
+    """Search within ``category`` and return normalized items."""
+
+    info = _category_info(category)
+    return socrata.search_items(
+        category,
+        info["dataset_id"],
+        info["dataset_url"],
+        q=q,
+        limit=limit,
+        offset=offset,
+        **kwargs,
+    )
+
+
+def get_item(category: str, item_id: str, **kwargs) -> dict | None:
+    """Fetch a single item by ``item_id`` within ``category``."""
+
+    info = _category_info(category)
+    return socrata.get_item(
+        category,
+        info["dataset_id"],
+        info["dataset_url"],
+        item_id,
+        **kwargs,
+    )

--- a/connectors/energystar/fixtures/item_computer.json
+++ b/connectors/energystar/fixtures/item_computer.json
@@ -1,0 +1,9 @@
+{
+  ":id": "1",
+  "esuid": "C123",
+  "brand_name": "CompBrand",
+  "model_number": "Model1",
+  "computer_type": "Laptop",
+  "annual_energy_use_kwh": "50",
+  "product_url": "https://example.com/comp1"
+}

--- a/connectors/energystar/fixtures/item_dehumidifier.json
+++ b/connectors/energystar/fixtures/item_dehumidifier.json
@@ -1,0 +1,10 @@
+{
+  ":id": "1",
+  "esuid": "D123",
+  "brand_name": "DryBrand",
+  "model_number": "DH100",
+  "capacity_pints_per_day": "30",
+  "energy_factor_l_kwh": "1.5",
+  "annual_energy_use_kwh": "200",
+  "product_url": "https://example.com/dh1"
+}

--- a/connectors/energystar/fixtures/item_heatpump.json
+++ b/connectors/energystar/fixtures/item_heatpump.json
@@ -1,0 +1,10 @@
+{
+  ":id": "1",
+  "esuid": "HP123",
+  "brand_name": "HeatBrand",
+  "model_number": "HP5000",
+  "hspf2": "10",
+  "seer2": "20",
+  "cooling_capacity_btu_hr": "24000",
+  "product_url": "https://example.com/hp1"
+}

--- a/connectors/energystar/fixtures/item_television.json
+++ b/connectors/energystar/fixtures/item_television.json
@@ -1,0 +1,10 @@
+{
+  ":id": "1",
+  "esuid": "TV123",
+  "brand_name": "BrandA",
+  "model_number": "A1",
+  "size_class": "55",
+  "annual_energy_use_kwh": "100",
+  "most_efficient": "Most Efficient 2024",
+  "product_url": "https://example.com/tv1"
+}

--- a/connectors/energystar/fixtures/search_computers.json
+++ b/connectors/energystar/fixtures/search_computers.json
@@ -1,0 +1,20 @@
+[
+  {
+    ":id": "1",
+    "esuid": "C123",
+    "brand_name": "CompBrand",
+    "model_number": "Model1",
+    "computer_type": "Laptop",
+    "annual_energy_use_kwh": "50",
+    "product_url": "https://example.com/comp1"
+  },
+  {
+    ":id": "2",
+    "esuid": "C456",
+    "brand_name": "CompBrand",
+    "model_number": "Model2",
+    "computer_type": "Desktop",
+    "annual_energy_use_kwh": "65",
+    "product_url": "https://example.com/comp2"
+  }
+]

--- a/connectors/energystar/fixtures/search_dehumidifiers.json
+++ b/connectors/energystar/fixtures/search_dehumidifiers.json
@@ -1,0 +1,22 @@
+[
+  {
+    ":id": "1",
+    "esuid": "D123",
+    "brand_name": "DryBrand",
+    "model_number": "DH100",
+    "capacity_pints_per_day": "30",
+    "energy_factor_l_kwh": "1.5",
+    "annual_energy_use_kwh": "200",
+    "product_url": "https://example.com/dh1"
+  },
+  {
+    ":id": "2",
+    "esuid": "D456",
+    "brand_name": "DryBrand",
+    "model_number": "DH200",
+    "capacity_pints_per_day": "40",
+    "energy_factor_l_kwh": "1.8",
+    "annual_energy_use_kwh": "220",
+    "product_url": "https://example.com/dh2"
+  }
+]

--- a/connectors/energystar/fixtures/search_heatpumps.json
+++ b/connectors/energystar/fixtures/search_heatpumps.json
@@ -1,0 +1,22 @@
+[
+  {
+    ":id": "1",
+    "esuid": "HP123",
+    "brand_name": "HeatBrand",
+    "model_number": "HP5000",
+    "hspf2": "10",
+    "seer2": "20",
+    "cooling_capacity_btu_hr": "24000",
+    "product_url": "https://example.com/hp1"
+  },
+  {
+    ":id": "2",
+    "esuid": "HP456",
+    "brand_name": "HeatBrand",
+    "model_number": "HP6000",
+    "hspf2": "11",
+    "seer2": "21",
+    "cooling_capacity_btu_hr": "36000",
+    "product_url": "https://example.com/hp2"
+  }
+]

--- a/connectors/energystar/fixtures/search_televisions.json
+++ b/connectors/energystar/fixtures/search_televisions.json
@@ -1,0 +1,21 @@
+[
+  {
+    ":id": "1",
+    "esuid": "TV123",
+    "brand_name": "BrandA",
+    "model_number": "A1",
+    "size_class": "55",
+    "annual_energy_use_kwh": "100",
+    "most_efficient": "Most Efficient 2024",
+    "product_url": "https://example.com/tv1"
+  },
+  {
+    ":id": "2",
+    "esuid": "TV456",
+    "brand_name": "BrandB",
+    "model_number": "B2",
+    "size_class": "65",
+    "annual_energy_use_kwh": "120",
+    "product_url": "https://example.com/tv2"
+  }
+]

--- a/connectors/energystar/providers/__init__.py
+++ b/connectors/energystar/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Provider implementations for the ENERGY STAR connector."""

--- a/connectors/energystar/providers/socrata.py
+++ b/connectors/energystar/providers/socrata.py
@@ -1,0 +1,133 @@
+"""Socrata provider for ENERGY STAR datasets."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List
+
+from .. import adapter
+
+__all__ = [
+    "SocrataHttpError",
+    "SocrataParseError",
+    "search_items",
+    "get_item",
+]
+
+USER_AGENT = "circl-energystar/0.1 (+https://github.com/andremair97/circl-docs)"
+
+
+class SocrataHttpError(Exception):
+    """Raised when the API returns a non-200 HTTP status."""
+
+
+class SocrataParseError(Exception):
+    """Raised when a response cannot be decoded as JSON."""
+
+
+_tokens: float = 0.0
+_last: float = time.monotonic()
+
+
+def _throttle() -> None:
+    """Tiny token bucket to avoid hammering the public API."""
+
+    global _tokens, _last
+    rate = float(os.getenv("ENERGY_STAR_RPS", "4"))
+    capacity = max(rate, 1)
+    now = time.monotonic()
+    elapsed = now - _last
+    _tokens = min(capacity, _tokens + elapsed * rate)
+    if _tokens < 1:
+        wait = (1 - _tokens) / rate
+        time.sleep(wait + random.uniform(0, 0.1))
+        now = time.monotonic()
+        elapsed = now - _last
+        _tokens = min(capacity, _tokens + elapsed * rate)
+    _tokens -= 1
+    _last = now
+
+
+def _request(url: str) -> List[Dict[str, Any]]:
+    """Perform a GET request and parse JSON."""
+
+    _throttle()
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/json",
+    }
+    token = os.getenv("ENERGY_STAR_APP_TOKEN")
+    if token:
+        headers["X-App-Token"] = token
+    req = urllib.request.Request(url, headers=headers)
+    timeout = float(os.getenv("ENERGY_STAR_TIMEOUT_SECONDS", "10"))
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = getattr(resp, "status", resp.getcode())
+            if status != 200:
+                raise SocrataHttpError(f"HTTP {status} for {url}")
+            raw = resp.read()
+    except urllib.error.URLError as exc:  # pragma: no cover - network issues
+        raise SocrataHttpError(str(exc)) from exc
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SocrataParseError(str(exc)) from exc
+    if isinstance(data, dict):
+        return [data]
+    return data
+
+
+def search_items(
+    category: str,
+    dataset_id: str,
+    dataset_url: str,
+    q: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> List[dict]:
+    """Search a dataset and return normalized items."""
+
+    base = os.getenv("ENERGY_STAR_BASE", "https://data.energystar.gov")
+    params = {
+        "$limit": str(max(1, min(int(limit), 100))),
+        "$offset": str(max(0, int(offset))),
+    }
+    if q:
+        params["$q"] = q
+    query = urllib.parse.urlencode(params)
+    url = f"{base}/resource/{dataset_id}.json?{query}"
+    rows = _request(url)
+    return [
+        adapter.normalize_item(category, dataset_id, dataset_url, row, url)
+        for row in rows
+    ]
+
+
+def get_item(
+    category: str,
+    dataset_id: str,
+    dataset_url: str,
+    item_id: str,
+) -> dict | None:
+    """Fetch a single item by ESUID or internal row id."""
+
+    base = os.getenv("ENERGY_STAR_BASE", "https://data.energystar.gov")
+    params = {"$limit": "1"}
+    if ":" in item_id:
+        _, row_id = item_id.split(":", 1)
+        params["$where"] = f":id='{row_id}'"
+    else:
+        params["$q"] = item_id
+    query = urllib.parse.urlencode(params)
+    url = f"{base}/resource/{dataset_id}.json?{query}"
+    rows = _request(url)
+    if not rows:
+        return None
+    return adapter.normalize_item(category, dataset_id, dataset_url, rows[0], url)

--- a/docs/connectors/energystar.md
+++ b/docs/connectors/energystar.md
@@ -1,0 +1,44 @@
+# ENERGY STAR Connector
+
+Fetches ENERGY STAR certified product data from the public
+[Socrata](https://data.energystar.gov) API. The connector keeps a small
+registry of categories and normalises results into a lightweight
+`UniversalEnergyProductV0` shape.
+
+## Environment
+
+Set optional environment variables to tune behaviour:
+
+- `ENERGY_STAR_APP_TOKEN` — API token for higher rate limits.
+- `ENERGY_STAR_TIMEOUT_SECONDS` — request timeout (default `10`).
+- `ENERGY_STAR_RPS` — requests per second throttle (default `4`).
+- `ENERGY_STAR_BASE` — override base URL (default `https://data.energystar.gov`).
+
+## CLI
+
+```bash
+python -m connectors.energystar.cli search --category televisions --q "Samsung 55" --limit 5
+python -m connectors.energystar.cli item --category televisions --id "TV123"
+```
+
+Example normalised record:
+
+```json
+{
+  "source": "energystar:socrata",
+  "provider": "socrata",
+  "category": "televisions",
+  "id": "TV123",
+  "title": "BrandA A1",
+  "identifiers": {"esuid": "TV123", "model_number": "A1", "upcs": []},
+  "links": {"product_page": "https://example.com/tv1"},
+  "metrics": {"annual_kwh": 100.0, "capacity": "55", "efficiency": null, "other": {}},
+  "labels": ["ENERGY STAR", "Most Efficient 2024"],
+  "provenance": {"source_url": "…", "fetched_at": "…"}
+}
+```
+
+ENERGY STAR is a registered trademark of the U.S. Environmental Protection
+Agency; using the logo or name may require permission. See
+[API User Essentials](https://www.energystar.gov/about/api-user-essentials) for
+usage guidelines.

--- a/tests/connectors/test_energystar_live_socrata.py
+++ b/tests/connectors/test_energystar_live_socrata.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+
+from connectors.energystar import client
+from connectors.energystar.providers.socrata import (
+    SocrataHttpError,
+    SocrataParseError,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("ENERGY_STAR_LIVE_TEST") != "1", reason="ENERGY_STAR_LIVE_TEST!=1"
+)
+
+
+def test_live_search():
+    try:
+        items = client.search_items("televisions", q="LG", limit=2)
+    except (SocrataHttpError, SocrataParseError) as exc:
+        pytest.xfail(f"API error: {exc}")
+    if not items:
+        pytest.xfail("empty result or rate limited")
+    assert items[0]["id"]
+    assert items[0]["title"]

--- a/tests/connectors/test_energystar_unit.py
+++ b/tests/connectors/test_energystar_unit.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from connectors.energystar import adapter, client
+from connectors.energystar.providers import socrata
+
+FIXTURES = Path(__file__).resolve().parents[2] / "connectors/energystar/fixtures"
+
+
+def load(name: str):
+    return json.loads((FIXTURES / name).read_text())
+
+
+@pytest.mark.parametrize(
+    "category, fixture, dataset_id",
+    [
+        ("televisions", "search_televisions.json", "pd96-rr3d"),
+        ("computers", "search_computers.json", "j7nq-iepp"),
+        ("dehumidifiers", "search_dehumidifiers.json", "mgiu-hu4z"),
+        ("heat_pumps", "search_heatpumps.json", "w7cv-9xjt"),
+    ],
+)
+def test_normalize_search(category, fixture, dataset_id):
+    rows = load(fixture)
+    dataset_url = f"https://data.energystar.gov/d/{dataset_id}"
+    items = [
+        adapter.normalize_item(category, dataset_id, dataset_url, row, "http://example")
+        for row in rows
+    ]
+    assert items
+    for item in items:
+        assert item["source"] == "energystar:socrata"
+        assert item["provider"] == "socrata"
+        assert item["category"] == category
+        assert item["id"]
+        assert item["title"]
+        assert item["identifiers"]["esuid"]
+        assert item["provenance"]["raw"]
+
+
+def test_sanitize_raw_truncates():
+    raw = {"big": "x" * 40000}
+    trimmed = adapter.sanitize_raw(raw, max_bytes=1000)
+    assert len(json.dumps(trimmed)) <= 1000
+
+
+def test_dispatcher_and_category_error():
+    orig = socrata.search_items
+    socrata.search_items = lambda category, dataset_id, dataset_url, **kw: ["ok"]
+    try:
+        items = client.search_items("televisions")
+        assert items == ["ok"]
+    finally:
+        socrata.search_items = orig
+    with pytest.raises(client.CategoryNotSupportedError):
+        client.search_items("unknown")


### PR DESCRIPTION
## Summary
- add standalone ENERGY STAR connector with Socrata provider and CLI
- document usage and env vars for ENERGY STAR datasets
- include offline fixtures and unit tests plus optional live test

## Testing
- `PYTHONPATH=. pytest tests/connectors/test_energystar_unit.py`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_68be0a437b4483218710445d6f936711