### PR TITLE
feat(connectors): add CDP Scores connector

### DIFF
--- a/changelog.d/feat-connector-cdp.md
+++ b/changelog.d/feat-connector-cdp.md
@@ -1,0 +1,1 @@
+feat(connectors): add isolated CDP Scores connector (CSV fixtures by default; opt-in live CSV URL; CLI, tests, docs)

--- a/connectors/cdp/README.md
+++ b/connectors/cdp/README.md
@@ -1,0 +1,20 @@
+# CDP Scores Connector
+
+Isolated connector for public corporate scores published by [CDP](https://www.cdp.net/).
+It ships with tiny CSV fixtures for offline tests and can optionally fetch a
+CSV/JSON export via a user-provided URL. The connector normalises records into
+the in-module `UniversalESGScoreV0` shape.
+
+## Maintainer quick commands
+
+```bash
+# Unit tests (offline)
+python -m pytest tests/connectors/test_cdp_unit.py -q
+
+# Opt-in live test
+CDP_LIVE_TEST=1 CDP_SCORES_CSV_URL="https://example.com/cdp_scores_2024.csv" \
+python -m pytest tests/connectors/test_cdp_live_csv.py -q
+
+# CLI smokes
+python -m connectors.cdp.cli search --provider csv_local --q "Alphabet" --year 2024 --limit 3
+```

--- a/connectors/cdp/__init__.py
+++ b/connectors/cdp/__init__.py
@@ -1,0 +1,1 @@
+"""CDP Scores connector package."""

--- a/connectors/cdp/adapter.py
+++ b/connectors/cdp/adapter.py
@@ -1,0 +1,110 @@
+"""Normalize CDP corporate scores to ``UniversalESGScoreV0``.
+
+The adapter keeps the mapping intentionally small so the connector remains
+self-contained and avoids pulling in global schemas. Raw payloads are trimmed to
+keep provenance lightweight.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from typing import Any, Dict, Optional, TypedDict
+
+
+class Scores(TypedDict, total=False):
+    climate_change: Optional[str]
+    water_security: Optional[str]
+    forests: Optional[str]
+
+
+class Links(TypedDict, total=False):
+    company: Optional[str]
+    cdp_profile: Optional[str]
+    source_csv: Optional[str]
+
+
+class UniversalESGScoreV0(TypedDict, total=False):
+    source: str
+    provider: str
+    org_name: str
+    org_id: Optional[str]
+    year: Optional[int]
+    country: Optional[str]
+    sector: Optional[str]
+    scores: Scores
+    disclosure_status: Optional[str]
+    links: Links
+    provenance: Dict[str, Any]
+
+
+def iso_now() -> str:
+    """Return current UTC time in ISO8601 with ``Z``."""
+
+    return _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def _truncate(value):
+    """Shallowly trim long strings/lists for provenance."""
+
+    if isinstance(value, str) and len(value) > 1000:
+        return value[:1000]
+    if isinstance(value, list) and len(value) > 50:
+        return value[:50]
+    return value
+
+
+def sanitize_raw(raw: dict, max_bytes: int = 30000) -> dict:
+    """Trim ``raw`` so its serialized form stays under ``max_bytes``."""
+
+    trimmed = {k: _truncate(v) for k, v in raw.items()}
+    blob = json.dumps(trimmed, ensure_ascii=False).encode("utf-8")
+    if len(blob) > max_bytes:
+        return {}
+    return trimmed
+
+
+def map_row(row: dict, provider: str, source_url: str | None) -> UniversalESGScoreV0:
+    """Map a raw score row into ``UniversalESGScoreV0``."""
+
+    scores: Scores = {}
+    if row.get("score_climate"):
+        scores["climate_change"] = row.get("score_climate")
+    if row.get("score_water"):
+        scores["water_security"] = row.get("score_water")
+    if row.get("score_forests"):
+        scores["forests"] = row.get("score_forests")
+
+    links: Links = {}
+    if row.get("company_url"):
+        links["company"] = row.get("company_url")
+    if row.get("cdp_profile"):
+        links["cdp_profile"] = row.get("cdp_profile")
+    if source_url:
+        links["source_csv"] = source_url
+
+    year: Optional[int] = None
+    if row.get("year"):
+        try:
+            year = int(row["year"])  # type: ignore[assignment]
+        except ValueError:
+            year = None
+
+    item: UniversalESGScoreV0 = {
+        "source": "cdp:scores",
+        "provider": provider,
+        "org_name": row.get("org_name") or row.get("organization") or "",
+        "org_id": row.get("org_id") or row.get("cdp_id") or row.get("lei"),
+        "year": year,
+        "country": row.get("country"),
+        "sector": row.get("sector"),
+        "scores": scores,
+        "disclosure_status": row.get("disclosure_status"),
+        "links": links,
+        "provenance": {
+            "source_url": source_url,
+            "fetched_at": iso_now(),
+            "raw": sanitize_raw(row),
+        },
+    }
+    return item

--- a/connectors/cdp/cli.py
+++ b/connectors/cdp/cli.py
@@ -1,0 +1,76 @@
+"""JSONL CLI for the CDP Scores connector."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import List
+
+from .client import ProviderNotAvailableError, get_org, search_scores
+from .providers import csv_http
+
+
+def _print(items: List[dict]) -> None:
+    for item in items:
+        print(json.dumps(item, ensure_ascii=False))
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="CDP Scores connector CLI")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_search = sub.add_parser("search", help="search organisations")
+    p_search.add_argument("--provider", required=True, choices=["csv_local", "csv_http"])
+    p_search.add_argument("--q", required=True)
+    p_search.add_argument("--year", type=int)
+    p_search.add_argument("--limit", type=int, default=20)
+    p_search.add_argument("--offset", type=int, default=0)
+    p_search.add_argument("--path")
+    p_search.add_argument("--url")
+
+    p_org = sub.add_parser("org", help="fetch a single organisation")
+    p_org.add_argument("--provider", required=True, choices=["csv_local", "csv_http"])
+    p_org.add_argument("--key", required=True)
+    p_org.add_argument("--year", type=int)
+    p_org.add_argument("--path")
+    p_org.add_argument("--url")
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.cmd == "search":
+            items = search_scores(
+                args.provider,
+                args.q,
+                year=args.year,
+                limit=args.limit,
+                offset=args.offset,
+                path=args.path,
+                url=args.url,
+            )
+            _print(items)
+        elif args.cmd == "org":
+            item = get_org(
+                args.provider,
+                args.key,
+                year=args.year,
+                path=args.path,
+                url=args.url,
+            )
+            if item:
+                _print([item])
+        else:
+            parser.print_help()
+            return 1
+    except ProviderNotAvailableError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    except (csv_http.CDPHttpError, csv_http.CDPParseError) as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/connectors/cdp/client.py
+++ b/connectors/cdp/client.py
@@ -1,0 +1,103 @@
+"""Provider dispatcher and tiny CSV/HTTP helpers for CDP Scores."""
+
+from __future__ import annotations
+
+import csv
+import io
+import os
+import random
+import time
+import urllib.error
+import urllib.request
+from typing import Dict, List
+
+USER_AGENT = "circl-cdp-connector/0.1 (+https://github.com/andremair97/circl-docs)"
+
+
+class ProviderNotAvailableError(Exception):
+    """Raised when an unknown provider is requested."""
+
+
+_tokens: float = 0.0
+_last: float = time.monotonic()
+
+
+def _throttle() -> None:
+    """Simple token-bucket rate limiter for HTTP providers."""
+
+    global _tokens, _last
+    rate = float(os.getenv("CDP_REQUESTS_PER_SEC", "4"))
+    capacity = max(rate, 1)
+    now = time.monotonic()
+    elapsed = now - _last
+    _tokens = min(capacity, _tokens + elapsed * rate)
+    if _tokens < 1:
+        wait = (1 - _tokens) / rate
+        time.sleep(wait + random.uniform(0, 0.1))
+        now = time.monotonic()
+        elapsed = now - _last
+        _tokens = min(capacity, _tokens + elapsed * rate)
+    _tokens -= 1
+    _last = now
+
+
+def http_get(url: str) -> tuple[bytes, str]:
+    """Fetch ``url`` with a custom ``User-Agent`` and return ``(data, content_type)``."""
+
+    _throttle()
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "text/csv, application/json",
+    }
+    req = urllib.request.Request(url, headers=headers)
+    timeout = float(os.getenv("CDP_TIMEOUT_SECONDS", "10"))
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        status = getattr(resp, "status", resp.getcode())
+        if status != 200:
+            raise urllib.error.URLError(f"HTTP {status}")
+        content_type = resp.headers.get("Content-Type", "")
+        data = resp.read()
+    return data, content_type
+
+
+def read_csv(text: str) -> List[Dict[str, str]]:
+    """Parse CSV ``text`` into a list of dict rows."""
+
+    reader = csv.DictReader(io.StringIO(text))
+    return list(reader)
+
+
+def _get_provider(name: str):
+    if name == "csv_local":
+        from .providers import csv_local as mod
+    elif name == "csv_http":
+        from .providers import csv_http as mod
+    else:
+        raise ProviderNotAvailableError(name)
+    return mod
+
+
+def search_scores(
+    provider: str,
+    query: str,
+    year: int | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    **kwargs,
+) -> List[Dict]:
+    """Dispatch ``search_scores`` to the chosen provider."""
+
+    mod = _get_provider(provider)
+    return mod.search_scores(query, year=year, limit=limit, offset=offset, **kwargs)
+
+
+def get_org(
+    provider: str,
+    org_key: str,
+    year: int | None = None,
+    **kwargs,
+) -> Dict | None:
+    """Dispatch ``get_org`` to the chosen provider."""
+
+    mod = _get_provider(provider)
+    return mod.get_org(org_key, year=year, **kwargs)

--- a/connectors/cdp/fixtures/sample_scores_2024.csv
+++ b/connectors/cdp/fixtures/sample_scores_2024.csv
@@ -1,0 +1,4 @@
+org_name,year,country,sector,score_climate,score_water,score_forests,disclosure_status,org_id,cdp_profile,company_url
+Alphabet Inc,2024,United States,Technology & Communications,A,B,,Disclosed,ALPH-2024,https://www.cdp.net/en/companies/70850,https://abc.xyz
+Nestlé S.A.,2024,Switzerland,Food & Beverage,A-,A,B,Disclosed,NEST-2024,https://www.cdp.net/en/companies/12345,https://www.nestle.com
+Local Widgets LLC,2024,Germany,Manufacturing,C,,D,Did Not Disclose,LOCAL-1,,https://localwidgets.example.com

--- a/connectors/cdp/fixtures/sample_scores_2024.json
+++ b/connectors/cdp/fixtures/sample_scores_2024.json
@@ -1,0 +1,28 @@
+[
+  {
+    "org_name": "Alphabet Inc",
+    "year": 2024,
+    "country": "United States",
+    "sector": "Technology & Communications",
+    "score_climate": "A",
+    "score_water": "B",
+    "score_forests": "",
+    "disclosure_status": "Disclosed",
+    "org_id": "ALPH-2024",
+    "cdp_profile": "https://www.cdp.net/en/companies/70850",
+    "company_url": "https://abc.xyz"
+  },
+  {
+    "org_name": "Nestlé S.A.",
+    "year": 2024,
+    "country": "Switzerland",
+    "sector": "Food & Beverage",
+    "score_climate": "A-",
+    "score_water": "A",
+    "score_forests": "B",
+    "disclosure_status": "Disclosed",
+    "org_id": "NEST-2024",
+    "cdp_profile": "https://www.cdp.net/en/companies/12345",
+    "company_url": "https://www.nestle.com"
+  }
+]

--- a/connectors/cdp/providers/__init__.py
+++ b/connectors/cdp/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Provider modules for the CDP Scores connector."""

--- a/connectors/cdp/providers/csv_http.py
+++ b/connectors/cdp/providers/csv_http.py
@@ -1,0 +1,79 @@
+"""HTTP provider for CDP Scores (opt-in live CSV/JSON)."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+from typing import Dict, List
+
+from .. import adapter, client
+
+__all__ = ["CDPHttpError", "CDPParseError", "search_scores", "get_org"]
+
+
+class CDPHttpError(Exception):
+    """Raised when the CSV URL cannot be fetched."""
+
+
+class CDPParseError(Exception):
+    """Raised when the payload cannot be parsed."""
+
+
+def _load_rows(url: str) -> List[Dict[str, str]]:
+    try:
+        data, content_type = client.http_get(url)
+    except urllib.error.URLError as exc:  # pragma: no cover - network errors
+        raise CDPHttpError(str(exc)) from exc
+    text = data.decode("utf-8")
+    try:
+        if "json" in content_type.lower() or text.lstrip().startswith("["):
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                rows = [parsed]
+            else:
+                rows = list(parsed)
+        else:
+            rows = client.read_csv(text)
+    except Exception as exc:
+        raise CDPParseError(str(exc)) from exc
+    return rows
+
+
+def _resolve_url(url: str | None) -> str:
+    src = url or os.getenv("CDP_SCORES_CSV_URL")
+    if not src:
+        raise CDPHttpError("CDP_SCORES_CSV_URL is not set; supply a CSV URL")
+    return src
+
+
+def search_scores(query, year=None, limit: int = 20, offset: int = 0, url: str | None = None, **_):
+    """Search scores from a remote CSV/JSON source."""
+
+    src = _resolve_url(url)
+    rows = _load_rows(src)
+    q = query.lower()
+    matches = []
+    for row in rows:
+        if year and row.get("year") and int(row["year"]) != year:
+            continue
+        name = row.get("org_name", "")
+        if q in name.lower():
+            matches.append(adapter.map_row(row, "csv_http", src))
+    return matches[offset : offset + limit]
+
+
+def get_org(org_key, year=None, url: str | None = None, **_):
+    """Fetch a single organisation by name or id from the remote source."""
+
+    src = _resolve_url(url)
+    rows = _load_rows(src)
+    key = org_key.lower()
+    for row in rows:
+        if year and row.get("year") and int(row["year"]) != year:
+            continue
+        name = row.get("org_name", "").lower()
+        oid = (row.get("org_id") or "").lower()
+        if key == name or key == oid:
+            return adapter.map_row(row, "csv_http", src)
+    return None

--- a/connectors/cdp/providers/csv_local.py
+++ b/connectors/cdp/providers/csv_local.py
@@ -1,0 +1,46 @@
+"""CSV-local provider using bundled fixtures for CDP Scores."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from .. import adapter, client
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "sample_scores_2024.csv"
+
+
+def _load_rows(path: str | None) -> List[Dict[str, str]]:
+    p = Path(path or FIXTURE)
+    text = p.read_text(encoding="utf-8")
+    return client.read_csv(text)
+
+
+def search_scores(query, year=None, limit: int = 20, offset: int = 0, path: str | None = None, **_):
+    """Search scores via substring match on ``org_name``."""
+
+    rows = _load_rows(path)
+    q = query.lower()
+    matches = []
+    for row in rows:
+        if year and row.get("year") and int(row["year"]) != year:
+            continue
+        name = row.get("org_name", "")
+        if q in name.lower():
+            matches.append(adapter.map_row(row, "csv_local", str(Path(path or FIXTURE))))
+    return matches[offset : offset + limit]
+
+
+def get_org(org_key, year=None, path: str | None = None, **_):
+    """Fetch a single organisation by name or id."""
+
+    rows = _load_rows(path)
+    key = org_key.lower()
+    for row in rows:
+        if year and row.get("year") and int(row["year"]) != year:
+            continue
+        name = row.get("org_name", "").lower()
+        oid = (row.get("org_id") or "").lower()
+        if key == name or key == oid:
+            return adapter.map_row(row, "csv_local", str(Path(path or FIXTURE)))
+    return None

--- a/docs/connectors/cdp.md
+++ b/docs/connectors/cdp.md
@@ -1,0 +1,47 @@
+# CDP Scores Connector
+
+The CDP Scores connector ingests public corporate scores (A–F) published by
+[CDP](https://www.cdp.net/). It is a read-only importer that normalises rows into
+a lightweight `UniversalESGScoreV0` shape.
+
+- No scraping or partner API calls.
+- Teams must only supply CSV exports or public datasets they are licensed to use.
+- Live mode is opt-in via `CDP_SCORES_CSV_URL` or the `--url` flag.
+
+## Schema snippet
+
+```python
+class UniversalESGScoreV0(TypedDict, total=False):
+    source: str  # "cdp:scores"
+    provider: str  # "csv_local" | "csv_http"
+    org_name: str
+    year: Optional[int]
+    scores: Dict[str, Optional[str]]
+    links: Dict[str, Optional[str]]
+    provenance: Dict[str, Any]
+```
+
+## CLI examples
+
+```bash
+python -m connectors.cdp.cli search --provider csv_local --q "Alphabet" --year 2024 --limit 3
+CDP_SCORES_CSV_URL="https://example.com/cdp_scores_2024.csv" \
+python -m connectors.cdp.cli search --provider csv_http --q "Nestlé" --year 2024 --limit 3
+```
+
+## Example output
+
+```json
+{
+  "source": "cdp:scores",
+  "provider": "csv_local",
+  "org_name": "Alphabet Inc",
+  "year": 2024,
+  "scores": {"climate_change": "A", "water_security": "B"}
+}
+```
+
+## Further reading
+
+- CDP public scores: <https://www.cdp.net/en/scores>
+- CDP Disclosure API overview: <https://help.cdp.net/en/articles/7804165-disclosure-api>

--- a/tests/connectors/test_cdp_live_csv.py
+++ b/tests/connectors/test_cdp_live_csv.py
@@ -1,0 +1,15 @@
+import os
+
+import pytest
+
+from connectors.cdp import client
+
+LIVE = os.getenv("CDP_LIVE_TEST") == "1"
+
+
+@pytest.mark.skipif(not LIVE or not os.getenv("CDP_SCORES_CSV_URL"), reason="live test disabled")
+def test_live_csv_smoke():
+    items = client.search_scores("csv_http", "Alphabet", year=2024)
+    assert items and items[0]["org_name"]
+    assert items[0]["scores"]
+    assert items[0]["year"] == 2024

--- a/tests/connectors/test_cdp_unit.py
+++ b/tests/connectors/test_cdp_unit.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from connectors.cdp import adapter, client
+
+FIXTURES = Path(__file__).resolve().parents[2] / "connectors/cdp/fixtures"
+
+def test_search_scores_local():
+    path = FIXTURES / "sample_scores_2024.csv"
+    items = client.search_scores("csv_local", "Alphabet", year=2024, path=str(path))
+    assert items and items[0]["source"] == "cdp:scores"
+    item = items[0]
+    assert item["provider"] == "csv_local"
+    assert item["scores"]["climate_change"] == "A"
+    assert "provenance" in item and item["provenance"]["raw"]
+
+def test_grade_passthrough():
+    path = FIXTURES / "sample_scores_2024.csv"
+    items = client.search_scores("csv_local", "Nestlé", year=2024, path=str(path))
+    assert items and items[0]["scores"]["climate_change"] == "A-"
+
+def test_year_filter():
+    path = FIXTURES / "sample_scores_2024.csv"
+    items = client.search_scores("csv_local", "Alphabet", year=2023, path=str(path))
+    assert items == []
+
+def test_adapter_json_fixture():
+    data = json.loads((FIXTURES / "sample_scores_2024.json").read_text())[0]
+    item = adapter.map_row(data, "csv_local", "sample")
+    assert item["scores"]["climate_change"] == data["score_climate"]
+
+def test_sanitize_raw_bounds():
+    big = {"a": "x" * 50000}
+    trimmed = adapter.sanitize_raw(big, max_bytes=1000)
+    assert len(json.dumps(trimmed)) <= 1000
+
+def test_bad_provider():
+    with pytest.raises(client.ProviderNotAvailableError):
+        client.search_scores("unknown", "x")


### PR DESCRIPTION
## Summary
- add isolated CDP Scores connector with in-module schema and provenance trimming
- support csv_local fixtures and csv_http live URL provider with tiny throttled HTTP client
- document usage and add unit tests with optional live smoke

## Testing
- `python -m pytest tests/connectors/test_cdp_unit.py -q`
- `python -m pytest tests/connectors/test_cdp_live_csv.py -q`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_68be0a4ed7c48321857568fb8aeb423a