### PR TITLE
feat(connectors): add EU Ecolabel/Green Seal certified lists connector

### DIFF
--- a/changelog.d/feat-connector-certified-lists.md
+++ b/changelog.d/feat-connector-certified-lists.md
@@ -1,0 +1,1 @@
+feat(connectors): add isolated EU Ecolabel / Green Seal certified-lists connector (fixtures by default; opt-in live with env keys); includes CLI, tests, docs

--- a/connectors/certified_lists/README.md
+++ b/connectors/certified_lists/README.md
@@ -1,0 +1,22 @@
+# Certified Lists Connector
+
+Isolated connector that normalises certification directory entries from the
+**EU Ecolabel** and **Green Seal** programs into a shared shape. It defaults to
+small fixture files for offline development; live HTTP calls are opt-in and
+require environment variables.
+
+## Maintainer quick commands
+
+```bash
+# Unit tests (offline)
+python -m pytest tests/connectors/test_certified_lists_unit.py -q
+
+# Opt-in live tests (tiny)
+CERTS_LIVE_TEST=1 GS_API_KEY=abc python -m pytest tests/connectors/test_certified_lists_live_green_seal.py -q
+CERTS_LIVE_TEST=1 EU_ECOLABEL_DATA_URL=https://example.com/export.csv \
+    python -m pytest tests/connectors/test_certified_lists_live_eu_ecolabel.py -q
+
+# CLI examples
+python -m connectors.certified_lists.cli search --provider eu_ecolabel --q "soap" --limit 2
+python -m connectors.certified_lists.cli item --provider green_seal --id "GS-41-456"
+```

--- a/connectors/certified_lists/__init__.py
+++ b/connectors/certified_lists/__init__.py
@@ -1,0 +1,1 @@
+"""Certified lists connector package."""

--- a/connectors/certified_lists/adapter.py
+++ b/connectors/certified_lists/adapter.py
@@ -1,0 +1,89 @@
+"""Normalisation helpers for certified lists connectors.
+
+Defines a minimal UniversalCertificationV0 shape used by provider modules so we
+avoid coupling to global schemas. Only standard library types are used.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Optional, TypedDict
+from datetime import datetime, timezone
+
+
+class Organization(TypedDict, total=False):
+    name: Optional[str]
+    country: Optional[str]
+    website: Optional[str]
+
+
+class CertificateStatus(TypedDict, total=False):
+    status: Optional[str]  # "active" | "expired" | "suspended" | "unknown"
+    issued: Optional[str]
+    expires: Optional[str]
+    standard: Optional[str]
+
+
+class Product(TypedDict, total=False):
+    brand: Optional[str]
+    name: Optional[str]
+    model: Optional[str]
+    gtin: Optional[str]
+    categories: List[str]
+
+
+class UniversalCertificationV0(TypedDict, total=False):
+    source: str
+    provider: str
+    certificate_id: str
+    product: Product
+    organization: Organization
+    status: CertificateStatus
+    marketplace_badges: List[str]
+    urls: Dict[str, str]
+    provenance: Dict
+
+
+def iso_now() -> str:
+    """Return current UTC time in ISO8601 format."""
+
+    return datetime.utcnow().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sanitize(obj, max_bytes: int) -> object:
+    """Recursively trim objects so their JSON representation stays within bounds."""
+
+    if isinstance(obj, str):
+        return obj[:max_bytes] + ("..." if len(obj) > max_bytes else "")
+    if isinstance(obj, list):
+        out = []
+        for item in obj:
+            out.append(_sanitize(item, max_bytes))
+            if len(json.dumps(out, ensure_ascii=False)) > max_bytes:
+                out[-1] = "..."
+                break
+        return out
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            out[k] = _sanitize(v, max_bytes)
+            if len(json.dumps(out, ensure_ascii=False)) > max_bytes:
+                out[k] = "..."
+                break
+        return out
+    return obj
+
+
+def sanitize_raw(raw: Dict, max_bytes: int = 30000) -> Dict:
+    """Return a copy of *raw* with large fields truncated.
+
+    This helps keep provenance blobs manageable. The function best-effort trims
+    very large strings and arrays; if the final payload still exceeds the
+    threshold, it returns a tiny fallback blob with a truncated JSON string.
+    """
+
+    sanitized = _sanitize(raw, max_bytes)
+    text = json.dumps(sanitized, ensure_ascii=False)
+    if len(text) > max_bytes:
+        return {"truncated": text[:max_bytes] + "..."}
+    return sanitized

--- a/connectors/certified_lists/cli.py
+++ b/connectors/certified_lists/cli.py
@@ -1,0 +1,71 @@
+"""JSON Lines CLI for certified lists connector."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import List
+
+from . import client
+from .providers import eu_ecolabel, green_seal
+
+
+EXCEPTIONS = (
+    client.ProviderNotAvailableError,
+    eu_ecolabel.EUEcolabelHttpError,
+    eu_ecolabel.EUEcolabelParseError,
+    green_seal.GreenSealAuthError,
+    green_seal.GreenSealHttpError,
+    green_seal.GreenSealParseError,
+)
+
+
+def _print(items: List[dict]) -> None:
+    for item in items:
+        print(json.dumps(item, ensure_ascii=False))
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Certified lists CLI")
+    parser.add_argument("--provider", required=True, choices=list(client.PROVIDERS.keys()))
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_search = sub.add_parser("search", help="search certified products")
+    p_search.add_argument("--q", default="")
+    p_search.add_argument("--limit", type=int, default=5)
+    p_search.add_argument("--offset", type=int, default=0)
+    p_search.add_argument("--category")
+    p_search.add_argument("--standard")
+
+    p_item = sub.add_parser("item", help="fetch single certificate")
+    p_item.add_argument("--id", required=True)
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.cmd == "search":
+            items = client.search_certified(
+                args.provider,
+                args.q,
+                limit=args.limit,
+                offset=args.offset,
+                category=args.category,
+                standard=args.standard,
+            )
+            _print(items)
+        elif args.cmd == "item":
+            item = client.get_certificate(args.provider, args.id)
+            if item:
+                _print([item])
+        else:
+            parser.print_help()
+            return 1
+    except EXCEPTIONS as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/connectors/certified_lists/client.py
+++ b/connectors/certified_lists/client.py
@@ -1,0 +1,37 @@
+"""Provider dispatcher for certified lists."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .providers import eu_ecolabel, green_seal
+
+PROVIDERS = {
+    "eu_ecolabel": eu_ecolabel,
+    "green_seal": green_seal,
+}
+
+
+class ProviderNotAvailableError(Exception):
+    pass
+
+
+def _get_provider(name: str):
+    try:
+        return PROVIDERS[name]
+    except KeyError as exc:
+        raise ProviderNotAvailableError(name) from exc
+
+
+def search_certified(provider: str, query: str, limit: int = 20, offset: int = 0, **kwargs) -> List[Dict]:
+    """Dispatch to provider search."""
+
+    mod = _get_provider(provider)
+    return mod.search_certified(query, limit=limit, offset=offset, **kwargs)
+
+
+def get_certificate(provider: str, cert_id: str, **kwargs) -> Dict | None:
+    """Dispatch to provider item fetch."""
+
+    mod = _get_provider(provider)
+    return mod.get_certificate(cert_id, **kwargs)

--- a/connectors/certified_lists/fixtures/eu_sample_products.csv
+++ b/connectors/certified_lists/fixtures/eu_sample_products.csv
@@ -1,0 +1,3 @@
+certificate_id,product_name,brand,model,gtin,categories,company,country,issued,expires,detail_url
+FR/012/001,Eco Laundry Detergent,EcoBrand,,1234567890123,Detergents,Eco Corp,FR,2021-01-01,2025-01-01,https://eu.ecolabel.eu/detail/FR-012-001
+DE/045/002,Green Soap,GreenBrand,,,Soaps,Green GmbH,DE,2020-06-15,2024-06-15,https://eu.ecolabel.eu/detail/DE-045-002

--- a/connectors/certified_lists/fixtures/eu_sample_products.json
+++ b/connectors/certified_lists/fixtures/eu_sample_products.json
@@ -1,0 +1,26 @@
+[
+  {
+    "certificate_id": "IT/099/003",
+    "product_name": "Eco Dishwasher",
+    "brand": "CleanCo",
+    "model": "DW-100",
+    "gtin": "9876543210987",
+    "categories": ["Dishwashers"],
+    "company": "CleanCo SRL",
+    "country": "IT",
+    "issued": "2022-03-10",
+    "expires": "2026-03-10",
+    "detail_url": "https://eu.ecolabel.eu/detail/IT-099-003"
+  },
+  {
+    "certificate_id": "ES/011/004",
+    "product_name": "Green Paint",
+    "brand": "ColorVida",
+    "categories": ["Paints"],
+    "company": "ColorVida SA",
+    "country": "ES",
+    "issued": "2019-09-01",
+    "expires": "2023-09-01",
+    "detail_url": "https://eu.ecolabel.eu/detail/ES-011-004"
+  }
+]

--- a/connectors/certified_lists/fixtures/gs_item.json
+++ b/connectors/certified_lists/fixtures/gs_item.json
@@ -1,0 +1,12 @@
+{
+  "id": "GS-41-456",
+  "name": "Eco Hand Soap",
+  "brand": "SoapCo",
+  "standard": "GS-41",
+  "category": "Hand Soaps",
+  "company": "SoapCo LLC",
+  "status": "active",
+  "issued": "2020-08-15",
+  "expires": "2023-08-15",
+  "detail_url": "https://certified.greenseal.org/products/gs-41-456"
+}

--- a/connectors/certified_lists/fixtures/gs_search.json
+++ b/connectors/certified_lists/fixtures/gs_search.json
@@ -1,0 +1,28 @@
+{
+  "results": [
+    {
+      "id": "GS-37-123",
+      "name": "Green Cleanser",
+      "brand": "GreenBrand",
+      "standard": "GS-37",
+      "category": "Cleaners",
+      "company": "GreenBrand Inc.",
+      "status": "active",
+      "issued": "2021-05-01",
+      "expires": "2024-05-01",
+      "detail_url": "https://certified.greenseal.org/products/gs-37-123"
+    },
+    {
+      "id": "GS-41-456",
+      "name": "Eco Hand Soap",
+      "brand": "SoapCo",
+      "standard": "GS-41",
+      "category": "Hand Soaps",
+      "company": "SoapCo LLC",
+      "status": "active",
+      "issued": "2020-08-15",
+      "expires": "2023-08-15",
+      "detail_url": "https://certified.greenseal.org/products/gs-41-456"
+    }
+  ]
+}

--- a/connectors/certified_lists/providers/__init__.py
+++ b/connectors/certified_lists/providers/__init__.py
@@ -1,0 +1,5 @@
+"""Provider implementations for certified lists."""
+
+from . import eu_ecolabel, green_seal
+
+__all__ = ["eu_ecolabel", "green_seal"]

--- a/connectors/certified_lists/providers/eu_ecolabel.py
+++ b/connectors/certified_lists/providers/eu_ecolabel.py
@@ -1,0 +1,158 @@
+"""EU Ecolabel provider.
+
+Fixture-first with optional live ingestion via CSV/JSON exports. Live mode is
+opt-in through the ``EU_ECOLABEL_DATA_URL`` environment variable.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import random
+import time
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+from .. import adapter
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+DEFAULT_TIMEOUT = int(os.getenv("EU_ECOLABEL_TIMEOUT_SECONDS", "10"))
+RATE = float(os.getenv("EU_ECOLABEL_REQUESTS_PER_SEC", "2"))
+DATA_URL = os.getenv("EU_ECOLABEL_DATA_URL")
+
+_NEXT_REQUEST = 0.0
+
+
+class EUEcolabelHttpError(Exception):
+    pass
+
+
+class EUEcolabelParseError(Exception):
+    pass
+
+
+def _throttle() -> None:
+    global _NEXT_REQUEST
+    now = time.time()
+    wait = _NEXT_REQUEST - now
+    if wait > 0:
+        time.sleep(wait + random.uniform(0, 0.25))
+    _NEXT_REQUEST = max(now, _NEXT_REQUEST) + 1 / RATE
+
+
+def _fetch(url: str) -> bytes:
+    _throttle()
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "circl-certified-eu/0.1 (+https://github.com/andremair97/circl-docs)",
+            "Accept": "text/csv, application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=DEFAULT_TIMEOUT) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network branch
+        raise EUEcolabelHttpError(f"HTTP error {exc.code}") from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - network branch
+        raise EUEcolabelHttpError(str(exc)) from exc
+
+
+def _load_live_data() -> List[Dict]:  # pragma: no cover - live path
+    if not DATA_URL:
+        return []
+    body = _fetch(DATA_URL)
+    if DATA_URL.endswith(".json"):
+        try:
+            rows = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise EUEcolabelParseError(str(exc)) from exc
+    else:
+        text = body.decode("utf-8", errors="ignore")
+        rows = list(csv.DictReader(text.splitlines()))
+    return [_normalise_row(row, DATA_URL) for row in rows]
+
+
+def _load_fixture_data() -> List[Dict]:
+    rows: List[Dict] = []
+    csv_text = (FIXTURES / "eu_sample_products.csv").read_text()
+    rows.extend(
+        _normalise_row(row, f"file://{FIXTURES / 'eu_sample_products.csv'}")
+        for row in csv.DictReader(csv_text.splitlines())
+    )
+    json_rows = json.loads((FIXTURES / "eu_sample_products.json").read_text())
+    rows.extend(
+        _normalise_row(row, f"file://{FIXTURES / 'eu_sample_products.json'}")
+        for row in json_rows
+    )
+    return rows
+
+
+def _load_all() -> List[Dict]:
+    return _load_live_data() if DATA_URL else _load_fixture_data()
+
+
+def _normalise_row(row: Dict, source_url: str) -> Dict:
+    item: adapter.UniversalCertificationV0 = {
+        "source": "cert:eu-ecolabel",
+        "provider": "eu_ecolabel",
+        "certificate_id": row.get("certificate_id", ""),
+        "product": {
+            "brand": row.get("brand"),
+            "name": row.get("product_name"),
+            "model": row.get("model"),
+            "gtin": row.get("gtin"),
+            "categories": [c.strip() for c in row.get("categories", [])
+                            if c and c.strip()] if isinstance(row.get("categories"), list)
+            else [c.strip() for c in str(row.get("categories", "")).split(";") if c.strip()],
+        },
+        "organization": {
+            "name": row.get("company"),
+            "country": row.get("country"),
+            "website": row.get("website"),
+        },
+        "status": {
+            "status": row.get("status", "unknown"),
+            "issued": row.get("issued"),
+            "expires": row.get("expires"),
+            "standard": row.get("standard"),
+        },
+        "marketplace_badges": [],
+        "urls": {"detail": row.get("detail_url", "")},
+        "provenance": {
+            "source_url": source_url,
+            "fetched_at": adapter.iso_now(),
+            "raw": adapter.sanitize_raw(row),
+        },
+    }
+    return item
+
+
+def search_certified(query: str, limit: int = 20, offset: int = 0, **_: Dict) -> List[Dict]:
+    """Search certified products/services."""
+
+    data = _load_all()
+    q = query.lower()
+    results = [
+        item
+        for item in data
+        if not q
+        or q in (item["product"].get("name", "").lower())
+        or q in (item["product"].get("brand", "").lower())
+        or any(q in c.lower() for c in item["product"].get("categories", []))
+        or q in ((item["product"].get("model") or "").lower())
+    ]
+    return results[offset : offset + limit]
+
+
+def get_certificate(cert_id: str, **_: Dict) -> Dict | None:
+    """Fetch a single certificate by id."""
+
+    data = _load_all()
+    for item in data:
+        if item.get("certificate_id") == cert_id:
+            return item
+    return None

--- a/connectors/certified_lists/providers/green_seal.py
+++ b/connectors/certified_lists/providers/green_seal.py
@@ -1,0 +1,165 @@
+"""Green Seal provider.
+
+Fixture-first; live HTTP requests require ``GS_API_KEY`` and follow the Green
+Seal Certified Directory API. The API base can be overridden with
+``GS_API_BASE``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+from .. import adapter
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+API_BASE = os.getenv("GS_API_BASE", "https://certified.greenseal.org/api")
+API_KEY = os.getenv("GS_API_KEY")
+DEFAULT_TIMEOUT = int(os.getenv("GS_TIMEOUT_SECONDS", "10"))
+RATE = float(os.getenv("GS_REQUESTS_PER_SEC", "4"))
+
+_NEXT_REQUEST = 0.0
+
+
+class GreenSealAuthError(Exception):
+    pass
+
+
+class GreenSealHttpError(Exception):
+    pass
+
+
+class GreenSealParseError(Exception):
+    pass
+
+
+def _throttle() -> None:
+    global _NEXT_REQUEST
+    now = time.time()
+    wait = _NEXT_REQUEST - now
+    if wait > 0:
+        time.sleep(wait + random.uniform(0, 0.25))
+    _NEXT_REQUEST = max(now, _NEXT_REQUEST) + 1 / RATE
+
+
+def _request(path: str, params: Dict[str, str] | None = None) -> bytes:
+    if not API_KEY:
+        raise GreenSealAuthError(
+            "GS_API_KEY required for live requests; obtain one per their terms"
+        )
+    _throttle()
+    if params is None:
+        params = {}
+    params.setdefault("key", API_KEY)
+    url = f"{API_BASE.rstrip('/')}/{path.lstrip('/')}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "circl-certified-gs/0.1 (+https://github.com/andremair97/circl-docs)",
+            "Accept": "application/json",
+            "Authorization": f"ApiKey {API_KEY}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=DEFAULT_TIMEOUT) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network branch
+        if exc.code == 401:
+            raise GreenSealAuthError("unauthorised") from exc
+        raise GreenSealHttpError(f"HTTP error {exc.code}") from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - network branch
+        raise GreenSealHttpError(str(exc)) from exc
+
+
+def _load_fixture_search() -> List[Dict]:
+    data = json.loads((FIXTURES / "gs_search.json").read_text())
+    return [_normalise_item(item, f"file://{FIXTURES / 'gs_search.json'}") for item in data["results"]]
+
+
+def _load_fixture_item() -> Dict:
+    item = json.loads((FIXTURES / "gs_item.json").read_text())
+    return _normalise_item(item, f"file://{FIXTURES / 'gs_item.json'}")
+
+
+def _normalise_item(item: Dict, source_url: str) -> Dict:
+    return {
+        "source": "cert:green-seal",
+        "provider": "green_seal",
+        "certificate_id": item.get("id", ""),
+        "product": {
+            "brand": item.get("brand"),
+            "name": item.get("name"),
+            "model": item.get("model"),
+            "gtin": item.get("gtin"),
+            "categories": [c for c in [item.get("category")] if c],
+        },
+        "organization": {
+            "name": item.get("company"),
+            "country": item.get("country"),
+            "website": item.get("website"),
+        },
+        "status": {
+            "status": item.get("status", "unknown"),
+            "issued": item.get("issued"),
+            "expires": item.get("expires"),
+            "standard": item.get("standard"),
+        },
+        "marketplace_badges": [],
+        "urls": {"detail": item.get("detail_url", "")},
+        "provenance": {
+            "source_url": source_url,
+            "fetched_at": adapter.iso_now(),
+            "raw": adapter.sanitize_raw(item),
+        },
+    }
+
+
+def search_certified(query: str, limit: int = 20, offset: int = 0, **kwargs) -> List[Dict]:
+    """Search the Green Seal directory."""
+
+    if not API_KEY:
+        items = _load_fixture_search()
+    else:  # pragma: no cover - live path
+        params = {"query": query, "limit": str(limit), "offset": str(offset)}
+        if "category" in kwargs and kwargs["category"]:
+            params["category"] = kwargs["category"]
+        if "standard" in kwargs and kwargs["standard"]:
+            params["standard"] = kwargs["standard"]
+        body = _request("products/search", params)
+        try:
+            raw = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise GreenSealParseError(str(exc)) from exc
+        items = [_normalise_item(item, f"{API_BASE}/products/search") for item in raw.get("results", [])]
+    q = query.lower()
+    filtered = [
+        i
+        for i in items
+        if not q
+        or q in (i["product"].get("name", "").lower())
+        or q in (i["product"].get("brand", "").lower())
+        or any(q in c.lower() for c in i["product"].get("categories", []))
+    ]
+    return filtered[offset : offset + limit]
+
+
+def get_certificate(cert_id: str, **_) -> Dict | None:
+    """Fetch a single certificate."""
+
+    if not API_KEY:
+        item = _load_fixture_item()
+        return item if item.get("certificate_id") == cert_id else None
+    # pragma: no cover - live path
+    body = _request(f"products/{urllib.parse.quote(cert_id)}")
+    try:
+        raw = json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise GreenSealParseError(str(exc)) from exc
+    return _normalise_item(raw, f"{API_BASE}/products/{cert_id}")

--- a/docs/connectors/certified_lists.md
+++ b/docs/connectors/certified_lists.md
@@ -1,0 +1,43 @@
+# Certified Lists Connector
+
+The certified-lists connector aggregates product certification data from two
+programs:
+
+- **EU Ecolabel** – public catalogues (ECAT) of certified products/services.
+- **Green Seal** – the Green Seal Certified Directory.
+
+Both providers normalise their records into a minimal `UniversalCertificationV0`
+shape for Circl's transparency layer.
+
+By default the connector runs fully offline using small fixture files. Maintainers
+may opt into live HTTP smoke tests:
+
+- EU Ecolabel: set `EU_ECOLABEL_DATA_URL` to a CSV or JSON export you control.
+- Green Seal: set `GS_API_KEY` (and optionally `GS_API_BASE`) per their API terms.
+
+## CLI examples
+
+```bash
+python -m connectors.certified_lists.cli search --provider eu_ecolabel --q "soap" --limit 2
+python -m connectors.certified_lists.cli search --provider green_seal --q "hand soap" --limit 2 --standard GS-41
+python -m connectors.certified_lists.cli item --provider green_seal --id "GS-41-456"
+```
+
+## Example normalised output
+
+```json
+{
+  "source": "cert:green-seal",
+  "provider": "green_seal",
+  "certificate_id": "GS-41-456",
+  "product": {"brand": "SoapCo", "name": "Eco Hand Soap", "categories": ["Hand Soaps"]},
+  "organization": {"name": "SoapCo LLC"},
+  "status": {"status": "active", "standard": "GS-41"},
+  "urls": {"detail": "https://certified.greenseal.org/products/gs-41-456"}
+}
+```
+
+## Notes
+
+- User-Agent strings identify Circl and requests are throttled politely.
+- Fixtures are intentionally tiny to keep tests fast.

--- a/tests/connectors/test_certified_lists_live_eu_ecolabel.py
+++ b/tests/connectors/test_certified_lists_live_eu_ecolabel.py
@@ -1,0 +1,15 @@
+import os
+
+import pytest
+
+from connectors.certified_lists import client
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("CERTS_LIVE_TEST") != "1" or not os.getenv("EU_ECOLABEL_DATA_URL"),
+    reason="CERTS_LIVE_TEST!=1 or missing EU_ECOLABEL_DATA_URL",
+)
+
+
+def test_live_fetch():
+    items = client.search_certified("eu_ecolabel", "", limit=1)
+    assert items and items[0]["certificate_id"]

--- a/tests/connectors/test_certified_lists_live_green_seal.py
+++ b/tests/connectors/test_certified_lists_live_green_seal.py
@@ -1,0 +1,19 @@
+import os
+
+import pytest
+
+from connectors.certified_lists import client
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("CERTS_LIVE_TEST") != "1" or not os.getenv("GS_API_KEY"),
+    reason="CERTS_LIVE_TEST!=1 or missing GS_API_KEY",
+)
+
+
+def test_live_search():
+    items = client.search_certified("green_seal", "soap", limit=1)
+    assert items
+    item = items[0]
+    assert item["certificate_id"]
+    assert item["product"]["name"]
+    assert item["status"].get("standard")

--- a/tests/connectors/test_certified_lists_unit.py
+++ b/tests/connectors/test_certified_lists_unit.py
@@ -1,0 +1,36 @@
+import json
+
+import pytest
+
+from connectors.certified_lists import adapter, client
+
+
+@pytest.mark.parametrize("provider,query", [
+    ("eu_ecolabel", "soap"),
+    ("green_seal", "soap"),
+])
+def test_search_and_normalise(provider: str, query: str):
+    items = client.search_certified(provider, query)
+    assert items, provider
+    first = items[0]
+    for key in ["source", "provider", "certificate_id", "product", "organization", "status", "provenance"]:
+        assert key in first
+    assert first["product"]["name"]
+    assert first["organization"]["name"]
+    assert first["status"]["status"]
+
+
+def test_get_certificate_dispatch():
+    item = client.get_certificate("green_seal", "GS-41-456")
+    assert item and item["certificate_id"] == "GS-41-456"
+
+
+def test_bad_provider():
+    with pytest.raises(client.ProviderNotAvailableError):
+        client.search_certified("unknown", "x")
+
+
+def test_sanitize_bounds():
+    raw = {"big": "x" * 40000}
+    san = adapter.sanitize_raw(raw, max_bytes=1000)
+    assert len(json.dumps(san)) <= 1000


### PR DESCRIPTION
## Summary
- add provider-pluggable certified lists connector with EU Ecolabel and Green Seal providers
- include CLI, docs, fixtures and tests for offline use with optional live HTTP via env vars

## Testing
- `python -m pytest tests/connectors/test_certified_lists_unit.py -q`
- `python -m pytest tests/connectors/test_certified_lists_live_green_seal.py -q`
- `python -m pytest tests/connectors/test_certified_lists_live_eu_ecolabel.py -q`
- `mkdocs build --strict >/tmp/mkdocs.log && tail -n 20 /tmp/mkdocs.log`

------
https://chatgpt.com/codex/tasks/task_e_68be0a63705c83218ceaf73e0012dadd