### PR TITLE
feat: add eBay connector UI page

### DIFF
--- a/apps/web/app/connectors/ebay/components/ResultCard.tsx
+++ b/apps/web/app/connectors/ebay/components/ResultCard.tsx
@@ -1,0 +1,28 @@
+import { EbayItem } from "@/src/lib/connectors/ebay/types";
+
+function Chip({ children }: { children: React.ReactNode }) {
+  return <span className="inline-block text-xs px-2 py-1 rounded bg-gray-100 border">{children}</span>;
+}
+
+// Card view highlighting key sustainability signals for an item.
+export function ResultCard({ i }: { i: EbayItem }) {
+  return (
+    <div className="rounded-xl border p-3 flex gap-3">
+      {i.image ? <img src={i.image} alt="" className="w-20 h-20 object-cover rounded" /> : <div className="w-20 h-20 bg-gray-50 rounded" />}
+      <div className="flex-1">
+        <div className="font-medium"><a href={i.url} target="_blank" rel="noreferrer">{i.title}</a></div>
+        <div className="text-sm text-gray-600">
+          {i.price ? `${i.price.value} ${i.price.currency}` : "—"} · {i.condition || "Condition unknown"}
+        </div>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {i.condition?.toUpperCase()?.includes("REFURB") && <Chip>Refurbished</Chip>}
+          {i.condition?.toUpperCase()?.includes("USED") && <Chip>Used</Chip>}
+          {i.pickupEligible && <Chip>Local pickup</Chip>}
+          {i.freeReturns && <Chip>Free returns</Chip>}
+          {i.seller?.topRated && <Chip>Top rated seller</Chip>}
+        </div>
+        <div className="text-xs text-gray-500 mt-1">{i.itemLocation}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/connectors/ebay/components/ResultTable.tsx
+++ b/apps/web/app/connectors/ebay/components/ResultTable.tsx
@@ -1,0 +1,35 @@
+import { EbayItem } from "@/src/lib/connectors/ebay/types";
+
+// Simple table layout to allow scanning multiple listings at once.
+export function ResultTable({ items }: { items: EbayItem[] }) {
+  return (
+    <div className="overflow-x-auto border rounded-xl">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="bg-gray-50">
+            <th className="text-left p-2">Title</th>
+            <th className="text-left p-2">Price</th>
+            <th className="text-left p-2">Condition</th>
+            <th className="text-left p-2">Pickup</th>
+            <th className="text-left p-2">Free returns</th>
+            <th className="text-left p-2">Seller</th>
+            <th className="text-left p-2">Location</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(i => (
+            <tr key={i.id} className="border-t">
+              <td className="p-2"><a href={i.url} target="_blank" rel="noreferrer" className="underline">{i.title}</a></td>
+              <td className="p-2">{i.price ? `${i.price.value} ${i.price.currency}` : "—"}</td>
+              <td className="p-2">{i.condition ?? "—"}</td>
+              <td className="p-2">{i.pickupEligible ? "Yes" : "No"}</td>
+              <td className="p-2">{i.freeReturns ? "Yes" : "No"}</td>
+              <td className="p-2">{i.seller?.username ?? "—"}</td>
+              <td className="p-2">{i.itemLocation ?? "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/app/connectors/ebay/components/SearchBar.tsx
+++ b/apps/web/app/connectors/ebay/components/SearchBar.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+
+// Client search form to update the query string without reloading the page.
+export default function SearchBar() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const initial = params.get("q") ?? "refurbished laptop";
+  const [q, setQ] = useState(initial);
+  const [pending, startTransition] = useTransition();
+
+  useEffect(() => { setQ(initial); }, [initial]);
+
+  return (
+    <form
+      onSubmit={(e) => { e.preventDefault(); startTransition(() =>
+        router.replace(`/connectors/ebay?q=${encodeURIComponent(q)}`)); }}
+      className="flex gap-2 items-center w-full"
+      aria-label="eBay search"
+    >
+      <input
+        className="w-full px-3 py-2 rounded-md border"
+        placeholder="Search eBay (e.g., refurbished laptop)"
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        name="q"
+        aria-label="Search query"
+      />
+      <button type="submit" disabled={pending} className="px-4 py-2 rounded-md border shadow text-sm" aria-busy={pending}>
+        {pending ? "Searching…" : "Search"}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/app/connectors/ebay/loading.tsx
+++ b/apps/web/app/connectors/ebay/loading.tsx
@@ -1,0 +1,4 @@
+// Lightweight loading indicator for suspense boundaries.
+export default function Loading() {
+  return <div className="animate-pulse">Loading eBay results…</div>;
+}

--- a/apps/web/app/connectors/ebay/page.tsx
+++ b/apps/web/app/connectors/ebay/page.tsx
@@ -1,0 +1,34 @@
+import SearchBar from "./components/SearchBar";
+import { searchEbay } from "@/src/lib/connectors/ebay/fetch";
+import { ResultCard } from "./components/ResultCard";
+import { ResultTable } from "./components/ResultTable";
+
+// Cache results for 30 minutes to balance freshness with API limits.
+export const revalidate = 1800;
+
+export default async function EbayPage({ searchParams }: { searchParams: { q?: string } }) {
+  const q = searchParams?.q ?? "refurbished laptop";
+  const items = await searchEbay(q);
+
+  return (
+    <main className="container mx-auto max-w-5xl p-4 space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">eBay</h1>
+        <p className="text-sm text-gray-600">Search listings and surface sustainability-relevant filters.</p>
+        <SearchBar />
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-medium">Top results ({items.length})</h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          {items.map(i => <ResultCard key={i.id} i={i} />)}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-medium">Table view</h2>
+        <ResultTable items={items} />
+      </section>
+    </main>
+  );
+}

--- a/apps/web/public/connectors/ebay/sample.json
+++ b/apps/web/public/connectors/ebay/sample.json
@@ -1,0 +1,27 @@
+{
+  "itemSummaries": [
+    {
+      "itemId": "v1|1234567890|0",
+      "title": "Dell Latitude 7420 – Refurbished",
+      "image": { "imageUrl": "https://i.ebayimg.com/images/g/abc/s-l1600.jpg" },
+      "price": { "value": "279.99", "currency": "GBP" },
+      "condition": "CERTIFIED_REFURBISHED",
+      "buyingOptions": ["FIXED_PRICE"],
+      "itemWebUrl": "https://www.ebay.co.uk/itm/1234567890",
+      "itemLocation": { "city": "Leeds", "country": "GB" },
+      "shippingOptions": [{ "localPickup": true }],
+      "returnTerms": { "returnsAccepted": true, "returnWithin": "30_DAYS" },
+      "seller": { "username": "TopTechRefurbs", "feedbackPercentage": "99.6", "feedbackScore": 12543, "topRatedSeller": true }
+    },
+    {
+      "itemId": "v1|2345678901|0",
+      "title": "Apple iPhone 12 128GB – Used",
+      "price": { "value": "239.00", "currency": "GBP" },
+      "condition": "USED",
+      "buyingOptions": ["AUCTION","BUY_IT_NOW"],
+      "itemWebUrl": "https://www.ebay.co.uk/itm/2345678901",
+      "itemLocation": { "city": "Glasgow", "country": "GB" },
+      "shippingOptions": [{ "localPickup": false }]
+    }
+  ]
+}

--- a/apps/web/src/lib/connectors/ebay/fetch.ts
+++ b/apps/web/src/lib/connectors/ebay/fetch.ts
@@ -26,15 +26,20 @@ export async function searchEbay(q: string): Promise<EbayItem[]> {
 
   try {
     if (!token) throw new Error("Missing EBAY_OAUTH_TOKEN");
-    const res = await fetch(url.toString(), {
-      headers: {
-        "Accept": "application/json",
-        "User-Agent": "circl-docs-ui",
-        "Authorization": `Bearer ${token}`,
-        "X-EBAY-C-MARKETPLACE-ID": market,
-      },
-      next: { revalidate: 1800 },
-    });
+    const res = await fetch(
+      url.toString(),
+      {
+        headers: {
+          "Accept": "application/json",
+          "User-Agent": "circl-docs-ui",
+          "Authorization": `Bearer ${token}`,
+          "X-EBAY-C-MARKETPLACE-ID": market,
+        },
+        // Tell Next.js to revalidate server-side results every 30 minutes.
+        // The cast preserves the `next` option while keeping strict TS happy.
+        next: { revalidate: 1800 },
+      } as RequestInit & { next: { revalidate: number } },
+    );
     if (!res.ok) throw new Error(`eBay ${res.status}`);
     const data = (await res.json()) as EbaySearchResponse;
     const items = (data.itemSummaries || []).map(transformEbayItem).filter(Boolean) as EbayItem[];

--- a/apps/web/src/lib/connectors/ebay/fetch.ts
+++ b/apps/web/src/lib/connectors/ebay/fetch.ts
@@ -1,0 +1,46 @@
+import { EbayItem, EbaySearchResponse } from "./types";
+import { transformEbayItem } from "./transform";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_BASE = "https://api.ebay.com/buy/browse/v1";
+
+// Queries the eBay Browse API, falling back to bundled sample data when offline
+// or when credentials are missing. This keeps builds and previews deterministic.
+export async function searchEbay(q: string): Promise<EbayItem[]> {
+  const base = process.env.EBAY_BROWSE_BASE || DEFAULT_BASE;
+  const market = process.env.EBAY_MARKETPLACE || "EBAY_GB";
+  const token = process.env.EBAY_OAUTH_TOKEN;
+
+  const url = new URL("/item_summary/search", base);
+  if (q?.trim()) url.searchParams.set("q", q.trim());
+  url.searchParams.set("limit", "20");
+
+  async function readSample(): Promise<EbayItem[]> {
+    // Use a small sample dataset so the UI always renders even without API access.
+    const samplePath = path.join(process.cwd(), "public/connectors/ebay/sample.json");
+    const raw = await fs.readFile(samplePath, "utf-8");
+    const data = JSON.parse(raw) as EbaySearchResponse;
+    return (data.itemSummaries || []).map(transformEbayItem).filter(Boolean) as EbayItem[];
+  }
+
+  try {
+    if (!token) throw new Error("Missing EBAY_OAUTH_TOKEN");
+    const res = await fetch(url.toString(), {
+      headers: {
+        "Accept": "application/json",
+        "User-Agent": "circl-docs-ui",
+        "Authorization": `Bearer ${token}`,
+        "X-EBAY-C-MARKETPLACE-ID": market,
+      },
+      next: { revalidate: 1800 },
+    });
+    if (!res.ok) throw new Error(`eBay ${res.status}`);
+    const data = (await res.json()) as EbaySearchResponse;
+    const items = (data.itemSummaries || []).map(transformEbayItem).filter(Boolean) as EbayItem[];
+    if (items.length) return items;
+    return await readSample();
+  } catch {
+    return await readSample();
+  }
+}

--- a/apps/web/src/lib/connectors/ebay/transform.test.ts
+++ b/apps/web/src/lib/connectors/ebay/transform.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { transformEbayItem } from "./transform";
+
+// Basic smoke tests to ensure the transformer handles common shapes.
+describe("transformEbayItem", () => {
+  it("maps core fields", () => {
+    const item = transformEbayItem({
+      itemId: "123",
+      title: "Refurb Laptop",
+      price: { value: "100", currency: "GBP" },
+      shippingOptions: [{ localPickup: true }],
+      returnTerms: { returnsAccepted: true, returnWithin: "30_DAYS" },
+    });
+    expect(item).toEqual(expect.objectContaining({
+      id: "123",
+      title: "Refurb Laptop",
+      pickupEligible: true,
+      freeReturns: true,
+    }));
+  });
+
+  it("returns null for empty input", () => {
+    expect(transformEbayItem({})).toBeNull();
+  });
+});

--- a/apps/web/src/lib/connectors/ebay/transform.ts
+++ b/apps/web/src/lib/connectors/ebay/transform.ts
@@ -1,0 +1,50 @@
+import { EbayItem } from "./types";
+
+// Normalises raw eBay API items so the UI can rely on a stable shape.
+// The eBay API returns a very loose schema, so `any` keeps the extractor resilient.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function transformEbayItem(raw: any): EbayItem | null {
+  if (!raw) return null;
+  const id = String(raw.itemId || raw.legacyItemId || raw.item_id || "");
+  const title = (raw.title || "").trim();
+  if (!id && !title) return null;
+
+  const image = raw.image?.imageUrl || raw.thumbnailImages?.[0]?.imageUrl;
+  // Use buy price when available, otherwise fall back to current bid.
+  const price = raw.price || raw.currentBidPrice || undefined;
+
+  const buyingOptions = Array.isArray(raw.buyingOptions) ? raw.buyingOptions : [];
+  const seller = raw.seller ?
+    {
+      username: raw.seller.username,
+      feedbackPercentage: raw.seller.feedbackPercentage ? Number(raw.seller.feedbackPercentage) : undefined,
+      feedbackScore: raw.seller.feedbackScore ? Number(raw.seller.feedbackScore) : undefined,
+      topRated: !!raw.seller.topRatedSeller,
+    } : undefined;
+
+  // Signal if local pickup is explicitly offered.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pickupEligible = !!raw.shippingOptions?.some((o: any) => o?.shippingCarrierCode === "PICKUP" || o?.localPickup);
+
+  // Surface free returns as a sustainability signal.
+  const freeReturns =
+    raw.returnTerms?.returnsAccepted && (raw.returnTerms?.refundMethod || raw.returnTerms?.returnWithin);
+
+  // Merge available location parts into a single human readable string.
+  const locationParts = [raw.itemLocation?.city, raw.itemLocation?.stateOrProvince, raw.itemLocation?.country]
+    .filter(Boolean).join(", ");
+
+  return {
+    id: id || title,
+    title,
+    image,
+    url: raw.itemWebUrl || raw.itemHref || "#",
+    price,
+    condition: raw.condition || raw.itemCondition,
+    buyingOptions,
+    itemLocation: locationParts || undefined,
+    pickupEligible,
+    freeReturns: !!freeReturns,
+    seller,
+  };
+}

--- a/apps/web/src/lib/connectors/ebay/types.ts
+++ b/apps/web/src/lib/connectors/ebay/types.ts
@@ -1,0 +1,17 @@
+export type EbayMoney = { value: string; currency: string };
+export type EbaySeller = { username?: string; feedbackPercentage?: number; feedbackScore?: number; topRated?: boolean };
+export type EbayItem = {
+  id: string;
+  title: string;
+  image?: string;
+  url: string;
+  price?: EbayMoney;
+  condition?: string;           // e.g., "USED", "NEW", "CERTIFIED_REFURBISHED"
+  buyingOptions: string[];      // e.g., ["FIXED_PRICE","AUCTION","BEST_OFFER","BUY_NOW"]
+  itemLocation?: string;        // city, state, country
+  pickupEligible?: boolean;     // derived from shippingOptions/localPickup
+  freeReturns?: boolean;        // derived from returnTerms
+  seller?: EbaySeller;
+};
+// Raw API response has arbitrary shape; `unknown` keeps typing strict.
+export type EbaySearchResponse = { itemSummaries?: unknown[] };

--- a/changelog/add-ebay-connector-ui.md
+++ b/changelog/add-ebay-connector-ui.md
@@ -1,0 +1,1 @@
+feat: add eBay connector UI page


### PR DESCRIPTION
## Summary
- add eBay search fetcher with sample fallback and transformer
- create /connectors/ebay page with search bar, cards and table view
- cover transformer with a small unit test

## Testing
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test`


------
https://chatgpt.com/codex/tasks/task_e_68be22fa7ba88321aa03c4d97c14e1b3