### PR TITLE
feat(web): add Library of Things connector page

### DIFF
--- a/apps/web/app/connectors/lot/components/Filters.tsx
+++ b/apps/web/app/connectors/lot/components/Filters.tsx
@@ -1,0 +1,88 @@
+'use client';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState, useTransition } from 'react';
+
+const DEFAULTS = {
+  location: process.env.NEXT_PUBLIC_LOT_DEFAULT_LOCATION ?? 'CP',
+};
+
+const LOCATIONS = [
+  { code: 'CP', name: 'Crystal Palace' },
+  { code: 'MO', name: 'Morden' },
+  { code: 'DL', name: 'Dalston' },
+  { code: 'DW', name: 'Dulwich' },
+];
+
+export default function Filters() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const [location, setLocation] = useState(
+    params.get('location') ?? DEFAULTS.location,
+  );
+  const [view, setView] = useState(params.get('view') ?? 'cards');
+  const [pending, start] = useTransition();
+
+  useEffect(() => {
+    setLocation(params.get('location') ?? DEFAULTS.location);
+    setView(params.get('view') ?? 'cards');
+  }, [params]);
+
+  function update(next: Partial<{ location: string; view: string }>) {
+    const q = new URLSearchParams(params.toString());
+    if (next.location) q.set('location', next.location);
+    if (next.view) q.set('view', next.view);
+    start(() => router.replace(`/connectors/lot?${q.toString()}`));
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <label className="text-sm">Location</label>
+      <select
+        value={location}
+        onChange={(e) => {
+          setLocation(e.target.value);
+          update({ location: e.target.value });
+        }}
+        className="rounded border px-2 py-1"
+        aria-label="Select location"
+      >
+        {LOCATIONS.map((l) => (
+          <option key={l.code} value={l.code}>
+            {l.name}
+          </option>
+        ))}
+      </select>
+
+      <div
+        className="ml-auto flex items-center gap-1"
+        role="group"
+        aria-label="View toggle"
+      >
+        <button
+          className={`rounded border px-2 py-1 ${
+            view === 'cards' ? 'bg-gray-100' : ''
+          }`}
+          onClick={() => {
+            setView('cards');
+            update({ view: 'cards' });
+          }}
+          disabled={pending}
+        >
+          Cards
+        </button>
+        <button
+          className={`rounded border px-2 py-1 ${
+            view === 'table' ? 'bg-gray-100' : ''
+          }`}
+          onClick={() => {
+            setView('table');
+            update({ view: 'table' });
+          }}
+          disabled={pending}
+        >
+          Table
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/connectors/lot/components/ItemCard.tsx
+++ b/apps/web/app/connectors/lot/components/ItemCard.tsx
@@ -1,0 +1,55 @@
+import { LotItem } from '@/src/lib/connectors/lot/types';
+
+function Badge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-block rounded border bg-gray-100 px-2 py-1 text-xs">
+      {children}
+    </span>
+  );
+}
+
+export function ItemCard({ item }: { item: LotItem }) {
+  return (
+    <div className="flex gap-3 rounded-xl border p-3">
+      {item.image ? (
+        <img
+          src={item.image}
+          alt=""
+          className="h-20 w-20 rounded object-cover"
+        />
+      ) : (
+        <div className="h-20 w-20 rounded bg-gray-50" />
+      )}
+      <div className="flex-1">
+        <div className="font-medium">{item.name}</div>
+        <div className="text-sm text-gray-600">{item.category ?? '—'}</div>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {typeof item.dailyPrice === 'number' && (
+            <Badge>£{item.dailyPrice.toFixed(2)}/day</Badge>
+          )}
+          {typeof item.deposit === 'number' && (
+            <Badge>Deposit £{item.deposit.toFixed(0)}</Badge>
+          )}
+          {item.nextAvailable && (
+            <Badge>
+              Next: {new Date(item.nextAvailable).toLocaleDateString()}
+            </Badge>
+          )}
+          {typeof item.co2eSavedKg === 'number' && (
+            <Badge>~{item.co2eSavedKg} kg CO₂e saved</Badge>
+          )}
+        </div>
+        {item.link && (
+          <a
+            className="mt-2 inline-block text-sm underline"
+            href={item.link}
+            target="_blank"
+            rel="noreferrer"
+          >
+            View item
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/connectors/lot/components/ItemTable.tsx
+++ b/apps/web/app/connectors/lot/components/ItemTable.tsx
@@ -1,0 +1,63 @@
+import { LotItem } from '@/src/lib/connectors/lot/types';
+
+export function ItemTable({ items }: { items: LotItem[] }) {
+  return (
+    <div className="overflow-x-auto rounded-xl border">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="bg-gray-50">
+            <th className="p-2 text-left">Name</th>
+            <th className="p-2 text-left">Category</th>
+            <th className="p-2 text-left">£/day</th>
+            <th className="p-2 text-left">Deposit</th>
+            <th className="p-2 text-left">Next available</th>
+            <th className="p-2 text-left">CO₂e saved</th>
+            <th className="p-2 text-left">Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((i) => (
+            <tr key={i.id} className="border-t">
+              <td className="p-2">{i.name}</td>
+              <td className="p-2">{i.category ?? '—'}</td>
+              <td className="p-2">
+                {typeof i.dailyPrice === 'number'
+                  ? i.dailyPrice.toFixed(2)
+                  : '—'}
+              </td>
+              <td className="p-2">
+                {typeof i.deposit === 'number'
+                  ? i.deposit.toFixed(0)
+                  : '—'}
+              </td>
+              <td className="p-2">
+                {i.nextAvailable
+                  ? new Date(i.nextAvailable).toLocaleDateString()
+                  : '—'}
+              </td>
+              <td className="p-2">
+                {typeof i.co2eSavedKg === 'number'
+                  ? `${i.co2eSavedKg} kg`
+                  : '—'}
+              </td>
+              <td className="p-2">
+                {i.link ? (
+                  <a
+                    className="underline"
+                    href={i.link}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Open
+                  </a>
+                ) : (
+                  '—'
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/app/connectors/lot/components/SearchBar.tsx
+++ b/apps/web/app/connectors/lot/components/SearchBar.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState, useTransition } from 'react';
+
+export default function SearchBar() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const initial = params.get('q') ?? 'drill';
+  const [q, setQ] = useState(initial);
+  const [pending, start] = useTransition();
+
+  useEffect(() => {
+    setQ(initial);
+  }, [initial]);
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const sp = new URLSearchParams(params.toString());
+        sp.set('q', q);
+        start(() => router.replace(`/connectors/lot?${sp.toString()}`));
+      }}
+      className="flex w-full items-center gap-2"
+      aria-label="Search Library of Things items"
+    >
+      <input
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        placeholder="Search items (e.g., drill, pressure washer)"
+        className="input input-bordered w-full rounded-md border px-3 py-2"
+        name="q"
+        aria-label="Search query"
+      />
+      <button
+        type="submit"
+        className="rounded-md border px-4 py-2 text-sm shadow"
+        disabled={pending}
+      >
+        {pending ? 'Searching…' : 'Search'}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/app/connectors/lot/loading.tsx
+++ b/apps/web/app/connectors/lot/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div className="animate-pulse">Loading Library of Things…</div>;
+}

--- a/apps/web/app/connectors/lot/page.tsx
+++ b/apps/web/app/connectors/lot/page.tsx
@@ -1,0 +1,47 @@
+import Filters from './components/Filters';
+import SearchBar from './components/SearchBar';
+import { searchLotItems } from '@/src/lib/connectors/lot/fetch';
+import { ItemCard } from './components/ItemCard';
+import { ItemTable } from './components/ItemTable';
+
+export const revalidate = 3600;
+
+export default async function LotPage({
+  searchParams,
+}: {
+  searchParams: { q?: string; location?: string; view?: string };
+}) {
+  const q = searchParams?.q ?? 'drill';
+  const location =
+    searchParams?.location ?? process.env.LOT_DEFAULT_LOCATION ?? 'CP';
+  const view = searchParams?.view ?? 'cards';
+  const items = await searchLotItems({ q, location });
+
+  return (
+    <main className="container mx-auto max-w-5xl space-y-6 p-4">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Library of Things (UK)</h1>
+        <p className="text-sm text-gray-600">
+          Browse borrowable items by location and see sustainability signals.
+        </p>
+        <div className="flex flex-col gap-3">
+          <Filters />
+          <SearchBar />
+        </div>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-medium">Top results ({items.length})</h2>
+        {view === 'table' ? (
+          <ItemTable items={items} />
+        ) : (
+          <div className="grid gap-3 md:grid-cols-2">
+            {items.map((it) => (
+              <ItemCard key={it.id} item={it} />
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/public/connectors/lot/sample.json
+++ b/apps/web/public/connectors/lot/sample.json
@@ -1,0 +1,53 @@
+{
+  "items": [
+    {
+      "id": "lot-cp-pressure-washer",
+      "name": "Heavy Duty Pressure Washer",
+      "category": "Cleaning",
+      "dailyPrice": 20,
+      "deposit": 30,
+      "locationCode": "CP",
+      "locationName": "Crystal Palace",
+      "image": "",
+      "nextAvailable": "2025-09-14",
+      "link": "https://example.org/pressure-washer",
+      "co2eSavedKg": 48
+    },
+    {
+      "id": "lot-mo-sewing-machine",
+      "name": "Sewing Machine",
+      "category": "DIY",
+      "dailyPrice": 5,
+      "deposit": 10,
+      "locationCode": "MO",
+      "locationName": "Morden",
+      "image": "",
+      "nextAvailable": "2025-09-10",
+      "link": "https://example.org/sewing-machine"
+    },
+    {
+      "id": "lot-dl-impact-drill",
+      "name": "Impact Drill",
+      "category": "DIY",
+      "dailyPrice": 7,
+      "deposit": 15,
+      "locationCode": "DL",
+      "locationName": "Dalston",
+      "image": "",
+      "nextAvailable": "2025-09-12",
+      "link": "https://example.org/impact-drill"
+    },
+    {
+      "id": "lot-dw-projector",
+      "name": "Home Projector",
+      "category": "Events",
+      "dailyPrice": 12,
+      "deposit": 20,
+      "locationCode": "DW",
+      "locationName": "Dulwich",
+      "image": "",
+      "nextAvailable": "2025-09-18",
+      "link": "https://example.org/projector"
+    }
+  ]
+}

--- a/apps/web/src/lib/connectors/lot/fetch.ts
+++ b/apps/web/src/lib/connectors/lot/fetch.ts
@@ -1,0 +1,10 @@
+import { LotItem, LotQuery } from './types';
+import { fetchJsonFeed } from './providers/json';
+import { fetchSample } from './providers/sample';
+
+// Searches Library of Things items, preferring the JSON feed when available.
+export async function searchLotItems(q: LotQuery): Promise<LotItem[]> {
+  const fromJson = await fetchJsonFeed(q).catch(() => null);
+  if (fromJson && fromJson.length) return fromJson;
+  return fetchSample(q);
+}

--- a/apps/web/src/lib/connectors/lot/providers/json.ts
+++ b/apps/web/src/lib/connectors/lot/providers/json.ts
@@ -1,0 +1,27 @@
+import { LotItem, LotQuery, LotResponse } from '../types';
+import { transformLotItem } from '../transform';
+
+const REVALIDATE = 3600;
+
+// Attempts to fetch from an external JSON feed; returns null on error/empty.
+export async function fetchJsonFeed(q: LotQuery): Promise<LotItem[] | null> {
+  const base = process.env.LOT_FEED_URL;
+  if (!base) return null;
+  const url = new URL(base);
+  if (q.q) url.searchParams.set('q', q.q);
+  if (q.location) url.searchParams.set('location', q.location);
+
+  const res = await fetch(url.toString(), {
+    headers: {
+      Accept: 'application/json',
+      'User-Agent': 'circl-docs-ui',
+    },
+    next: { revalidate: REVALIDATE },
+  }).catch(() => null);
+  if (!res || !res.ok) return null;
+  const data = (await res.json()) as LotResponse;
+  const items = (data.items ?? [])
+    .map(transformLotItem)
+    .filter(Boolean) as LotItem[];
+  return items.length ? items : null;
+}

--- a/apps/web/src/lib/connectors/lot/providers/json.ts
+++ b/apps/web/src/lib/connectors/lot/providers/json.ts
@@ -1,6 +1,11 @@
 import { LotItem, LotQuery, LotResponse } from '../types';
 import { transformLotItem } from '../transform';
 
+// Custom fetch init that allows Next.js-specific `next.revalidate` while keeping type safety.
+interface NextRequestInit extends RequestInit {
+  next?: { revalidate?: number };
+}
+
 const REVALIDATE = 3600;
 
 // Attempts to fetch from an external JSON feed; returns null on error/empty.
@@ -17,7 +22,7 @@ export async function fetchJsonFeed(q: LotQuery): Promise<LotItem[] | null> {
       'User-Agent': 'circl-docs-ui',
     },
     next: { revalidate: REVALIDATE },
-  }).catch(() => null);
+  } as NextRequestInit).catch(() => null);
   if (!res || !res.ok) return null;
   const data = (await res.json()) as LotResponse;
   const items = (data.items ?? [])

--- a/apps/web/src/lib/connectors/lot/providers/sample.ts
+++ b/apps/web/src/lib/connectors/lot/providers/sample.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { LotItem, LotQuery, LotResponse } from '../types';
+import { transformLotItem } from '../transform';
+
+// Reads bundled sample data deterministically.
+export async function fetchSample(q: LotQuery): Promise<LotItem[]> {
+  const p = path.join(
+    process.cwd(),
+    'apps/web/public/connectors/lot/sample.json',
+  );
+  const raw = await fs.readFile(p, 'utf-8');
+  const data = JSON.parse(raw) as LotResponse;
+  let items = (data.items ?? [])
+    .map(transformLotItem)
+    .filter(Boolean) as LotItem[];
+
+  if (q.location) items = items.filter((i) => i.locationCode === q.location);
+  if (q.q?.trim()) {
+    const s = q.q.trim().toLowerCase();
+    items = items.filter((i) => i.name.toLowerCase().includes(s));
+  }
+  return items;
+}

--- a/apps/web/src/lib/connectors/lot/transform.test.ts
+++ b/apps/web/src/lib/connectors/lot/transform.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { transformLotItem } from './transform';
+
+// Minimal tests to ensure transformer behaviour stays predictable.
+describe('transformLotItem', () => {
+  it('maps basic fields and infers CO2e by category', () => {
+    const raw = { id: 1, name: 'Drill', category: 'DIY', locationCode: 'CP' };
+    const item = transformLotItem(raw);
+    expect(item?.name).toBe('Drill');
+    expect(item?.deposit).toBeUndefined();
+    expect(item?.co2eSavedKg).toBe(30);
+  });
+});

--- a/apps/web/src/lib/connectors/lot/transform.ts
+++ b/apps/web/src/lib/connectors/lot/transform.ts
@@ -1,0 +1,38 @@
+import { LotItem } from './types';
+
+// Demo kgCO2e saved estimates by category
+const CO2E_BY_CATEGORY: Record<string, number> = {
+  Cleaning: 45,
+  DIY: 30,
+  Gardening: 35,
+  Events: 15,
+};
+
+// Normalises a raw Library of Things item into our internal shape.
+// Tolerates missing data and infers a rough CO2e saved estimate.
+export function transformLotItem(x: any): LotItem | null {
+  if (!x) return null;
+  const id = String(x.id ?? x.slug ?? x.code ?? '');
+  const name = (x.name ?? x.title ?? '').trim();
+  if (!id && !name) return null;
+
+  const category = x.category ?? x.group ?? undefined;
+  const co2e =
+    typeof x.co2eSavedKg === 'number'
+      ? x.co2eSavedKg
+      : (category && CO2E_BY_CATEGORY[category]) || undefined;
+
+  return {
+    id: id || name,
+    name,
+    category,
+    dailyPrice: typeof x.dailyPrice === 'number' ? x.dailyPrice : undefined,
+    deposit: typeof x.deposit === 'number' ? x.deposit : undefined,
+    locationCode: String(x.locationCode ?? x.location ?? 'XX'),
+    locationName: x.locationName ?? undefined,
+    image: x.image ?? x.imageUrl ?? undefined,
+    nextAvailable: x.nextAvailable ?? undefined,
+    link: x.link ?? x.url ?? undefined,
+    co2eSavedKg: co2e,
+  };
+}

--- a/apps/web/src/lib/connectors/lot/transform.ts
+++ b/apps/web/src/lib/connectors/lot/transform.ts
@@ -10,29 +10,30 @@ const CO2E_BY_CATEGORY: Record<string, number> = {
 
 // Normalises a raw Library of Things item into our internal shape.
 // Tolerates missing data and infers a rough CO2e saved estimate.
-export function transformLotItem(x: any): LotItem | null {
-  if (!x) return null;
-  const id = String(x.id ?? x.slug ?? x.code ?? '');
-  const name = (x.name ?? x.title ?? '').trim();
+export function transformLotItem(x: unknown): LotItem | null {
+  if (!x || typeof x !== 'object') return null;
+  const obj = x as Record<string, unknown>;
+  const id = String(obj.id ?? obj.slug ?? obj.code ?? '');
+  const name = (obj.name ?? obj.title ?? '').toString().trim();
   if (!id && !name) return null;
 
-  const category = x.category ?? x.group ?? undefined;
+  const category = (obj.category ?? obj.group ?? undefined) as string | undefined;
   const co2e =
-    typeof x.co2eSavedKg === 'number'
-      ? x.co2eSavedKg
+    typeof obj.co2eSavedKg === 'number'
+      ? obj.co2eSavedKg
       : (category && CO2E_BY_CATEGORY[category]) || undefined;
 
   return {
     id: id || name,
     name,
     category,
-    dailyPrice: typeof x.dailyPrice === 'number' ? x.dailyPrice : undefined,
-    deposit: typeof x.deposit === 'number' ? x.deposit : undefined,
-    locationCode: String(x.locationCode ?? x.location ?? 'XX'),
-    locationName: x.locationName ?? undefined,
-    image: x.image ?? x.imageUrl ?? undefined,
-    nextAvailable: x.nextAvailable ?? undefined,
-    link: x.link ?? x.url ?? undefined,
+    dailyPrice: typeof obj.dailyPrice === 'number' ? obj.dailyPrice : undefined,
+    deposit: typeof obj.deposit === 'number' ? obj.deposit : undefined,
+    locationCode: String(obj.locationCode ?? obj.location ?? 'XX'),
+    locationName: obj.locationName as string | undefined,
+    image: (obj.image ?? obj.imageUrl ?? undefined) as string | undefined,
+    nextAvailable: obj.nextAvailable as string | undefined,
+    link: (obj.link ?? obj.url ?? undefined) as string | undefined,
     co2eSavedKg: co2e,
   };
 }

--- a/apps/web/src/lib/connectors/lot/types.ts
+++ b/apps/web/src/lib/connectors/lot/types.ts
@@ -17,4 +17,6 @@ export type LotQuery = {
   location?: string;
 };
 
-export type LotResponse = { items: any[] };
+// Raw response shape from Library of Things providers.
+// Uses `unknown` for items to avoid assuming structure prior to transform.
+export type LotResponse = { items: unknown[] };

--- a/apps/web/src/lib/connectors/lot/types.ts
+++ b/apps/web/src/lib/connectors/lot/types.ts
@@ -1,0 +1,20 @@
+export type LotItem = {
+  id: string;
+  name: string;
+  category?: string;
+  dailyPrice?: number; // in GBP
+  deposit?: number; // in GBP
+  locationCode: string; // e.g., "CP", "MO"
+  locationName?: string;
+  image?: string;
+  nextAvailable?: string;
+  link?: string;
+  co2eSavedKg?: number;
+};
+
+export type LotQuery = {
+  q?: string;
+  location?: string;
+};
+
+export type LotResponse = { items: any[] };

--- a/changelog/add-lot-connector-ui.md
+++ b/changelog/add-lot-connector-ui.md
@@ -1,0 +1,1 @@
+feat: add Library of Things connector UI


### PR DESCRIPTION
## Summary
- introduce Library of Things connector types, transformer, fetcher with optional JSON feed and sample fallback
- add `/connectors/lot` route with search, location filters, and card/table views

## Testing
- `pnpm test`

## Manual Verification
- `pnpm -C apps/web dev` → open `/connectors/lot`
- try queries: "drill", "sewing", "projector"
- toggle between Cards/Table; switch Location
- set `LOT_FEED_URL` to an invalid value and confirm sample data renders
- optionally set `NEXT_PUBLIC_LOT_DEFAULT_LOCATION` to change default


------
https://chatgpt.com/codex/tasks/task_e_68be2337ebd88321b785f9fef662b7d2