### PR TITLE
feat(ui): add ENERGY STAR connector page

### DIFF
--- a/apps/web/app/connectors/energy-star/components/ResultCard.tsx
+++ b/apps/web/app/connectors/energy-star/components/ResultCard.tsx
@@ -1,0 +1,28 @@
+import { EnergyStarProduct } from "@/src/lib/connectors/energy-star/types";
+
+function Badge({ children }: { children: React.ReactNode }) {
+  return <span className="inline-block text-xs px-2 py-1 rounded bg-gray-100 border">{children}</span>;
+}
+
+/**
+ * Card view highlights sustainability-relevant fields without overwhelming the user.
+ */
+export function ResultCard({ item }: { item: EnergyStarProduct }) {
+  return (
+    <div className="rounded-xl border p-3 flex flex-col gap-2">
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="font-medium">{item.brand} {item.model}</div>
+        <Badge>{item.category}</Badge>
+      </div>
+      <div className="text-sm text-gray-600">{item.capacity ?? "—"}</div>
+      <div className="flex flex-wrap gap-2 mt-1">
+        {typeof item.annualKwh === "number" && <Badge>{item.annualKwh} kWh/yr</Badge>}
+        {item.mostEfficient && <Badge>Most Efficient</Badge>}
+        {item.certifiedDate && <Badge>Certified {item.certifiedDate}</Badge>}
+      </div>
+      {item.productUrl && (
+        <a className="text-sm underline mt-1" href={item.productUrl} target="_blank" rel="noreferrer">Product page</a>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/connectors/energy-star/components/ResultTable.tsx
+++ b/apps/web/app/connectors/energy-star/components/ResultTable.tsx
@@ -1,0 +1,37 @@
+import { EnergyStarProduct } from "@/src/lib/connectors/energy-star/types";
+
+/**
+ * Compact tabular representation for power users or dense comparisons.
+ */
+export function ResultTable({ items }: { items: EnergyStarProduct[] }) {
+  return (
+    <div className="overflow-x-auto border rounded-xl">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="bg-gray-50">
+            <th className="text-left p-2">Brand</th>
+            <th className="text-left p-2">Model</th>
+            <th className="text-left p-2">Category</th>
+            <th className="text-left p-2">Capacity</th>
+            <th className="text-left p-2">kWh/yr</th>
+            <th className="text-left p-2">Most Efficient</th>
+            <th className="text-left p-2">Certified</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(p => (
+            <tr key={p.id} className="border-t">
+              <td className="p-2">{p.brand}</td>
+              <td className="p-2">{p.model}</td>
+              <td className="p-2">{p.category}</td>
+              <td className="p-2">{p.capacity ?? "-"}</td>
+              <td className="p-2">{typeof p.annualKwh === "number" ? p.annualKwh : "-"}</td>
+              <td className="p-2">{p.mostEfficient ? "Yes" : "No"}</td>
+              <td className="p-2">{p.certifiedDate ?? "-"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/app/connectors/energy-star/components/SearchBar.tsx
+++ b/apps/web/app/connectors/energy-star/components/SearchBar.tsx
@@ -1,0 +1,67 @@
+"use client";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+
+const CATEGORIES = ["Refrigerators","Dishwashers","Monitors"] as const;
+
+/**
+ * Lightweight search bar to push query/category into the route.
+ * Keeps the page server-rendered while giving client-side feedback.
+ */
+export default function SearchBar() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const initialQ = params.get("q") ?? "";
+  const initialCat = (params.get("category") ?? "Refrigerators") as (typeof CATEGORIES)[number];
+
+  const [q, setQ] = useState(initialQ);
+  const [category, setCategory] = useState<(typeof CATEGORIES)[number]>(initialCat);
+  const [pending, start] = useTransition();
+
+  // Sync local state when URL params change.
+  useEffect(() => { setQ(initialQ); }, [initialQ]);
+  useEffect(() => { setCategory(initialCat); }, [initialCat]);
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const usp = new URLSearchParams();
+        if (q.trim()) usp.set("q", q.trim());
+        usp.set("category", category);
+        // Transition to avoid blocking the UI while server renders.
+        start(() => router.replace(`/connectors/energy-star?${usp.toString()}`));
+      }}
+      className="flex flex-col md:flex-row gap-2 items-stretch md:items-center w-full"
+      aria-label="ENERGY STAR search"
+    >
+      <label className="sr-only" htmlFor="q">Search by brand or model</label>
+      <input
+        id="q"
+        value={q}
+        onChange={(e)=>setQ(e.target.value)}
+        placeholder="Search by brand or model (e.g., Bosch, VX27Q)"
+        className="input input-bordered w-full px-3 py-2 rounded-md border"
+        name="q"
+      />
+      <label className="sr-only" htmlFor="category">Category</label>
+      <select
+        id="category"
+        value={category}
+        onChange={(e)=>setCategory(e.target.value as (typeof CATEGORIES)[number])}
+        className="px-3 py-2 rounded-md border"
+        name="category"
+      >
+        {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+      </select>
+      <button
+        type="submit"
+        disabled={pending}
+        className="px-4 py-2 rounded-md border shadow text-sm"
+        aria-busy={pending}
+      >
+        {pending ? "Searching…" : "Search"}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/app/connectors/energy-star/loading.tsx
+++ b/apps/web/app/connectors/energy-star/loading.tsx
@@ -1,0 +1,4 @@
+export default function Loading() {
+  // Simple loading skeleton to indicate server rendering.
+  return <div className="animate-pulse">Loading ENERGY STAR products…</div>;
+}

--- a/apps/web/app/connectors/energy-star/page.tsx
+++ b/apps/web/app/connectors/energy-star/page.tsx
@@ -1,0 +1,43 @@
+import SearchBar from "./components/SearchBar";
+import { searchEnergyStar } from "@/src/lib/connectors/energy-star/fetch";
+import { ResultCard } from "./components/ResultCard";
+import { ResultTable } from "./components/ResultTable";
+import { EnergyStarCategory } from "@/src/lib/connectors/energy-star/types";
+
+// Revalidate daily to balance freshness with provider limits.
+export const revalidate = 86400;
+
+/**
+ * Server-rendered page displaying ENERGY STAR search results.
+ */
+export default async function EnergyStarPage({
+  searchParams
+}: { searchParams: { q?: string; category?: EnergyStarCategory } }) {
+  const q = searchParams?.q ?? "";
+  const category = (searchParams?.category as EnergyStarCategory) ?? "Refrigerators";
+  const items = await searchEnergyStar({ q, category });
+
+  return (
+    <main className="container mx-auto max-w-5xl p-4 space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">ENERGY STAR</h1>
+        <p className="text-sm text-gray-600">
+          Search certified products and view efficiency signals (kWh/yr, Most Efficient, certification date).
+        </p>
+        <SearchBar />
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-medium">Top results ({items.length})</h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          {items.map(item => <ResultCard key={item.id} item={item} />)}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-medium">Table view</h2>
+        <ResultTable items={items} />
+      </section>
+    </main>
+  );
+}

--- a/apps/web/public/connectors/energy-star/sample.json
+++ b/apps/web/public/connectors/energy-star/sample.json
@@ -1,0 +1,37 @@
+{
+  "items": [
+    {
+      "id": "ref-001",
+      "category": "Refrigerators",
+      "brand": "CoolCo",
+      "model": "CCRF-25A",
+      "capacity": "25 cu ft",
+      "annualKwh": 410,
+      "mostEfficient": true,
+      "productUrl": "https://example.com/coolco-ccrf-25a",
+      "certifiedDate": "2024-11-15"
+    },
+    {
+      "id": "dw-010",
+      "category": "Dishwashers",
+      "brand": "Sparkle",
+      "model": "SP-DW600",
+      "capacity": "15 place settings",
+      "annualKwh": 220,
+      "mostEfficient": false,
+      "productUrl": "https://example.com/sparkle-sp-dw600",
+      "certifiedDate": "2025-02-02"
+    },
+    {
+      "id": "mon-777",
+      "category": "Monitors",
+      "brand": "ViewMax",
+      "model": "VX27Q",
+      "capacity": "27-inch",
+      "annualKwh": 28,
+      "mostEfficient": true,
+      "productUrl": "https://example.com/viewmax-vx27q",
+      "certifiedDate": "2025-03-10"
+    }
+  ]
+}

--- a/apps/web/src/lib/connectors/energy-star/fetch.ts
+++ b/apps/web/src/lib/connectors/energy-star/fetch.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { PROVIDERS } from "./providers";
+import {
+  EnergyStarCategory,
+  EnergyStarProduct,
+  EnergyStarResponse,
+  EnergyStarSearchParams,
+} from "./types";
+import { mapProviderRecordToProduct } from "./transform";
+
+const DEFAULT_CATEGORIES: EnergyStarCategory[] = ["Refrigerators","Dishwashers","Monitors"];
+
+async function readSample(): Promise<EnergyStarProduct[]> {
+  // Read bundled fallback data so the connector works without env configuration.
+  const p = path.join(process.cwd(), "public/connectors/energy-star/sample.json");
+  const raw = await fs.readFile(p, "utf-8");
+  const json = JSON.parse(raw) as EnergyStarResponse;
+  return json.items ?? [];
+}
+
+async function fetchCategory(category: EnergyStarCategory): Promise<EnergyStarProduct[]> {
+  const envName = PROVIDERS[category].envUrl;
+  const url = process.env[envName];
+
+  // No provider configured → skip remote and let caller fall through to sample.
+  if (!url) return [];
+
+  const headers: Record<string, string> = {
+    "Accept": "application/json",
+    "User-Agent": "circl-docs-ui",
+  };
+  if (process.env.ENERGY_STAR_API_TOKEN) {
+    headers["Authorization"] = `Bearer ${process.env.ENERGY_STAR_API_TOKEN}`;
+  }
+
+  const res = await fetch(
+    url,
+    { headers, next: { revalidate: 86400 } } as RequestInit & { next: { revalidate: number } }
+  );
+  if (!res.ok) throw new Error(`${category} provider ${res.status}`);
+  const data = await res.json();
+
+  const dataObj = data as { results?: unknown[] };
+  const items = Array.isArray(data) ? data : (Array.isArray(dataObj.results) ? dataObj.results : []);
+  return items
+    .map((r: unknown) => mapProviderRecordToProduct(r, category))
+    .filter(Boolean) as EnergyStarProduct[];
+}
+
+/** High-level search with optional text and category filter. */
+export async function searchEnergyStar(params: EnergyStarSearchParams = {}): Promise<EnergyStarProduct[]> {
+  const categoryList = params.category ? [params.category] : DEFAULT_CATEGORIES;
+
+  let collected: EnergyStarProduct[] = [];
+  try {
+    // Try remote providers (if any envs set)
+    const perCat = await Promise.all(categoryList.map(fetchCategory));
+    collected = perCat.flat();
+  } catch (_e) {
+    // ignore and fall back
+  }
+
+  if (!collected.length) {
+    // Fallback to sample
+    collected = await readSample();
+    // If a category was chosen, filter sample to it
+    if (params.category) collected = collected.filter(i => i.category === params.category);
+  }
+
+  // Text filter (brand/model contains q)
+  const q = params.q?.trim().toLowerCase();
+  if (q) {
+    collected = collected.filter(i =>
+      i.brand.toLowerCase().includes(q) || i.model.toLowerCase().includes(q)
+    );
+  }
+
+  // Stable-ish ordering: Most Efficient first, then lowest annual kWh, then brand/model
+  collected.sort((a, b) => {
+    const me = (b.mostEfficient ? 1 : 0) - (a.mostEfficient ? 1 : 0);
+    if (me !== 0) return me;
+    const ak = (a.annualKwh ?? Number.POSITIVE_INFINITY) - (b.annualKwh ?? Number.POSITIVE_INFINITY);
+    if (ak !== 0) return ak;
+    return (a.brand + a.model).localeCompare(b.brand + b.model);
+  });
+
+  return collected;
+}

--- a/apps/web/src/lib/connectors/energy-star/providers.ts
+++ b/apps/web/src/lib/connectors/energy-star/providers.ts
@@ -1,0 +1,11 @@
+import { EnergyStarCategory } from "./types";
+
+type ProviderConfig = {
+  envUrl: string;     // name of env var that holds JSON endpoint
+};
+
+export const PROVIDERS: Record<EnergyStarCategory, ProviderConfig> = {
+  Refrigerators: { envUrl: "ENERGY_STAR_PROVIDER_REFRIGERATORS_URL" },
+  Dishwashers:   { envUrl: "ENERGY_STAR_PROVIDER_DISHWASHERS_URL"   },
+  Monitors:      { envUrl: "ENERGY_STAR_PROVIDER_MONITORS_URL"      },
+} as const;

--- a/apps/web/src/lib/connectors/energy-star/transform.test.ts
+++ b/apps/web/src/lib/connectors/energy-star/transform.test.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "vitest";
+import { mapProviderRecordToProduct } from "./transform";
+
+test("maps minimal provider record", () => {
+  const p = mapProviderRecordToProduct({ brand_name: "CoolCo", model_number: "X1", annual_kwh: "123" }, "Refrigerators");
+  expect(p?.brand).toBe("CoolCo");
+  expect(p?.model).toBe("X1");
+  expect(p?.annualKwh).toBe(123);
+  expect(p?.category).toBe("Refrigerators");
+});

--- a/apps/web/src/lib/connectors/energy-star/transform.ts
+++ b/apps/web/src/lib/connectors/energy-star/transform.ts
@@ -1,0 +1,66 @@
+import { EnergyStarProduct, EnergyStarCategory } from "./types";
+
+/**
+ * Map arbitrary provider JSON (record-per-product) into EnergyStarProduct.
+ * Keep this tolerant to missing fields; return null to drop a record.
+ */
+export function mapProviderRecordToProduct(
+  raw: unknown,
+  category: EnergyStarCategory
+): EnergyStarProduct | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+
+  // Heuristic field extraction with common fallbacks:
+  const id = String(
+    r["id"] ?? r["model_number"] ?? r["model number"] ?? r["_id"] ?? r["guid"] ?? ""
+  ).trim();
+  const brand = String(
+    r["brand"] ?? r["brand_name"] ?? r["Brand"] ?? ""
+  ).trim();
+  const model = String(
+    r["model"] ?? r["model_number"] ?? r["Model"] ?? ""
+  ).trim();
+
+  if (!brand && !model) return null;
+  const annualKwhNum = (() => {
+    const v = r["annual_kwh"] ?? r["annual energy use (kwh/yr)"] ?? r["kwh_year"] ?? r["annual_energy"] ?? undefined;
+    const n = typeof v === "string" ? parseFloat(v.replace(/[^\d.]/g, "")) : (typeof v === "number" ? v : undefined);
+    return Number.isFinite(n!) ? (n as number) : undefined;
+  })();
+
+  const mostEff = (() => {
+    const v = r["most_efficient"] ?? r["most efficient"] ?? r["is_most_efficient"] ?? r["mostEfficient"];
+    if (typeof v === "boolean") return v;
+    if (typeof v === "string") return ["yes","true","y","1"].includes(v.toLowerCase());
+    return undefined;
+  })();
+
+  const capacityVal =
+    r["capacity"] ??
+    r["capacity (cu ft)"] ??
+    r["place settings"] ??
+    r["screen_size"] ??
+    r["screen size"] ??
+    undefined;
+
+  const productUrl =
+    r["product_url"] ?? r["product url"] ?? r["url"] ?? undefined;
+
+  const certifiedDate =
+    r["date_certified"] ?? r["date certified"] ?? r["certified"] ?? undefined;
+
+  return {
+    id: id || `${brand}-${model}` || `${brand}-${Math.random().toString(36).slice(2)}`,
+    category,
+    brand,
+    model,
+    variant: (r["variant"] ?? r["model variant"] ?? undefined) as string | undefined,
+    productUrl: productUrl as string | undefined,
+    certifiedDate: certifiedDate as string | undefined,
+    annualKwh: annualKwhNum,
+    capacity: typeof capacityVal === "number" ? String(capacityVal) : (capacityVal as string | undefined),
+    mostEfficient: mostEff,
+    notes: r["notes"] as string | undefined,
+  };
+}

--- a/apps/web/src/lib/connectors/energy-star/types.ts
+++ b/apps/web/src/lib/connectors/energy-star/types.ts
@@ -1,0 +1,27 @@
+export type EnergyStarCategory =
+  | "Refrigerators"
+  | "Dishwashers"
+  | "Monitors";
+
+export type EnergyStarProduct = {
+  id: string;
+  category: EnergyStarCategory;
+  brand: string;
+  model: string;
+  variant?: string;
+  productUrl?: string;
+  certifiedDate?: string;    // ISO string
+  annualKwh?: number;        // yearly energy use
+  capacity?: string;         // e.g., "25 cu ft" or "15 place settings" or "27-inch"
+  mostEfficient?: boolean;   // ENERGY STAR Most Efficient flag
+  notes?: string;
+};
+
+export type EnergyStarSearchParams = {
+  q?: string;                // text to match brand/model
+  category?: EnergyStarCategory;
+};
+
+export type EnergyStarResponse = {
+  items: EnergyStarProduct[];
+};

--- a/changelog/energy-star-ui-connector.md
+++ b/changelog/energy-star-ui-connector.md
@@ -1,0 +1,1 @@
+feat: add ENERGY STAR connector UI


### PR DESCRIPTION
## Summary
- add ENERGY STAR connector page with search and results views
- implement Energy Star fetcher with provider registry and sample fallback
- document change in changelog

## Testing
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test`
- `pnpm -C apps/web build`


------
https://chatgpt.com/codex/tasks/task_e_68be231d64548321a2654050dbb548bf