### PR TITLE
feat: add isolated CDP connector UI

### DIFF
--- a/apps/web/public/connectors/cdp/sample-cities.json
+++ b/apps/web/public/connectors/cdp/sample-cities.json
@@ -1,0 +1,20 @@
+[
+  {
+    "city": "London",
+    "country": "United Kingdom",
+    "year": 2021,
+    "total_emissions_tco2e": 31200000,
+    "per_capita_emissions": 3.5,
+    "scope": "City-wide",
+    "inventory_method": "GPC Basic"
+  },
+  {
+    "city": "Manchester",
+    "country": "United Kingdom",
+    "year": 2020,
+    "total_emissions_tco2e": 7100000,
+    "per_capita_emissions": 4.1,
+    "scope": "City-wide",
+    "inventory_method": "GPC Basic"
+  }
+]

--- a/apps/web/public/connectors/cdp/sample-corporate.json
+++ b/apps/web/public/connectors/cdp/sample-corporate.json
@@ -1,0 +1,4 @@
+[
+  { "company": "Example PLC", "year": 2024, "theme": "climate", "score": "A-", "country": "United Kingdom", "isin": "GB00EXAMPL01", "ticker": "EXM" },
+  { "company": "Widgets SA", "year": 2024, "theme": "water", "score": "B", "country": "France", "isin": "FR00WIDGET01", "ticker": "WID" }
+]

--- a/apps/web/src/app/connectors/cdp/components/CityCard.tsx
+++ b/apps/web/src/app/connectors/cdp/components/CityCard.tsx
@@ -1,0 +1,20 @@
+import { CityEmission } from "@/app/../src/lib/connectors/cdp/types";
+
+function Badge({ children }: { children: React.ReactNode }) {
+  return <span className="inline-block text-xs px-2 py-1 rounded bg-gray-100 border">{children}</span>;
+}
+
+export default function CityCard({ item }: { item: CityEmission }) {
+  return (
+    <div className="rounded-xl border p-3 flex flex-col gap-2">
+      <div className="text-base font-medium">{item.city}{item.country ? `, ${item.country}` : ""}</div>
+      <div className="text-sm text-gray-600">{item.year ?? "—"}</div>
+      <div className="flex flex-wrap gap-2">
+        {item.totalEmissionsTCO2e !== undefined && <Badge>Total {Math.round(item.totalEmissionsTCO2e).toLocaleString()} tCO₂e</Badge>}
+        {item.perCapitaTCO2e !== undefined && <Badge>Per-capita {item.perCapitaTCO2e}</Badge>}
+        {item.scope && <Badge>{item.scope}</Badge>}
+      </div>
+      {item.inventoryMethod && <div className="text-xs text-gray-500">Method: {item.inventoryMethod}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/app/connectors/cdp/components/CitySearchForm.tsx
+++ b/apps/web/src/app/connectors/cdp/components/CitySearchForm.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect, useTransition } from "react";
+
+export default function CitySearchForm() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const [city, setCity] = useState(params.get("city") ?? "London");
+  const [country, setCountry] = useState(params.get("country") ?? "");
+  const [from, setFrom] = useState(params.get("from") ?? "2018");
+  const [to, setTo] = useState(params.get("to") ?? "2024");
+  const [pending, start] = useTransition();
+
+  useEffect(() => {
+    setCity(params.get("city") ?? "London");
+    setCountry(params.get("country") ?? "");
+    setFrom(params.get("from") ?? "2018");
+    setTo(params.get("to") ?? "2024");
+  }, [params]);
+
+  return (
+    <form
+      onSubmit={(e)=>{ e.preventDefault();
+        const q = new URLSearchParams(params.toString());
+        q.set("tab","cities");
+        q.set("city", city);
+        if (country) q.set("country", country); else q.delete("country");
+        q.set("from", from); q.set("to", to);
+        start(()=>router.replace(`/connectors/cdp?${q.toString()}`));
+      }}
+      className="grid md:grid-cols-5 gap-2"
+      aria-label="Search CDP city emissions"
+    >
+      <input className="border rounded px-2 py-1" value={city} onChange={e=>setCity(e.target.value)} placeholder="City (e.g., London)" aria-label="City"/>
+      <input className="border rounded px-2 py-1" value={country} onChange={e=>setCountry(e.target.value)} placeholder="Country (optional)" aria-label="Country"/>
+      <input className="border rounded px-2 py-1" value={from} onChange={e=>setFrom(e.target.value)} placeholder="From year" aria-label="From year"/>
+      <input className="border rounded px-2 py-1" value={to} onChange={e=>setTo(e.target.value)} placeholder="To year" aria-label="To year"/>
+      <button className="border rounded px-3 py-1" disabled={pending} aria-busy={pending}>{pending ? "Searching…" : "Search"}</button>
+    </form>
+  );
+}

--- a/apps/web/src/app/connectors/cdp/components/CityTable.tsx
+++ b/apps/web/src/app/connectors/cdp/components/CityTable.tsx
@@ -1,0 +1,32 @@
+import { CityEmission } from "@/app/../src/lib/connectors/cdp/types";
+
+export default function CityTable({ rows }: { rows: CityEmission[] }) {
+  return (
+    <div className="overflow-x-auto border rounded-xl">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="bg-gray-50">
+            <th className="p-2 text-left">City</th>
+            <th className="p-2 text-left">Country</th>
+            <th className="p-2 text-left">Year</th>
+            <th className="p-2 text-left">Total tCO₂e</th>
+            <th className="p-2 text-left">Per-capita</th>
+            <th className="p-2 text-left">Scope</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(r=>(
+            <tr key={r.id} className="border-t">
+              <td className="p-2">{r.city}</td>
+              <td className="p-2">{r.country ?? "-"}</td>
+              <td className="p-2">{r.year ?? "-"}</td>
+              <td className="p-2">{r.totalEmissionsTCO2e !== undefined ? Math.round(r.totalEmissionsTCO2e).toLocaleString() : "-"}</td>
+              <td className="p-2">{r.perCapitaTCO2e ?? "-"}</td>
+              <td className="p-2">{r.scope ?? "-"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/app/connectors/cdp/components/CorpCard.tsx
+++ b/apps/web/src/app/connectors/cdp/components/CorpCard.tsx
@@ -1,0 +1,13 @@
+import { CorpScore } from "@/app/../src/lib/connectors/cdp/types";
+
+export default function CorpCard({ s }: { s: CorpScore }) {
+  return (
+    <div className="rounded-xl border p-3 flex items-center justify-between">
+      <div>
+        <div className="font-medium">{s.company}</div>
+        <div className="text-sm text-gray-600">{s.year} • {s.theme.toUpperCase()}</div>
+      </div>
+      <div className="text-xl font-semibold">{s.score}</div>
+    </div>
+  );
+}

--- a/apps/web/src/app/connectors/cdp/components/TabToggle.tsx
+++ b/apps/web/src/app/connectors/cdp/components/TabToggle.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export default function TabToggle() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const tab = params.get("tab") || "cities";
+  const setTab = (t: string) => {
+    const q = new URLSearchParams(params.toString());
+    q.set("tab", t);
+    router.replace(`/connectors/cdp?${q.toString()}`);
+  };
+  const btn = "px-3 py-1 rounded-md border text-sm";
+  return (
+    <div className="inline-flex gap-2" role="tablist" aria-label="CDP data tabs">
+      <button className={`${btn} ${tab==="cities"?"bg-gray-100":""}`} onClick={()=>setTab("cities")} role="tab" aria-selected={tab==="cities"}>Cities & Regions (Open)</button>
+      <button className={`${btn} ${tab==="corporate"?"bg-gray-100":""}`} onClick={()=>setTab("corporate")} role="tab" aria-selected={tab==="corporate"}>Corporate Scores (Licensed)</button>
+    </div>
+  );
+}

--- a/apps/web/src/app/connectors/cdp/loading.tsx
+++ b/apps/web/src/app/connectors/cdp/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div className="animate-pulse">Loading CDP data…</div>;
+}

--- a/apps/web/src/app/connectors/cdp/page.tsx
+++ b/apps/web/src/app/connectors/cdp/page.tsx
@@ -1,0 +1,58 @@
+import TabToggle from "./components/TabToggle";
+import CitySearchForm from "./components/CitySearchForm";
+import CityCard from "./components/CityCard";
+import CityTable from "./components/CityTable";
+import CorpCard from "./components/CorpCard";
+import { findCityEmissions } from "@/app/../src/lib/connectors/cdp/cities_fetch";
+import { getCorpScores } from "@/app/../src/lib/connectors/cdp/corp_fetch";
+
+export const revalidate = 3600;
+
+export default async function CdpPage({ searchParams }: { searchParams: Record<string,string | undefined> }) {
+  const tab = searchParams.tab ?? "cities";
+
+  const city = searchParams.city ?? "London";
+  const country = searchParams.country ?? "";
+  const fromYear = Number(searchParams.from ?? 2018);
+  const toYear = Number(searchParams.to ?? 2024);
+
+  const cities = await findCityEmissions({ city, country, fromYear, toYear, limit: 24 });
+
+  let corp: Awaited<ReturnType<typeof getCorpScores>> = [];
+  if (tab === "corporate") {
+    corp = await getCorpScores({ company: searchParams.company, year: Number(searchParams.year || 2024), theme: searchParams.theme });
+  }
+
+  return (
+    <main className="container mx-auto max-w-5xl p-4 space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">CDP</h1>
+        <p className="text-sm text-gray-600">
+          Explore open city climate data from CDP’s Open Data Portal. Corporate scores appear if a licensed feed is configured.
+        </p>
+        <div className="flex items-center justify-between">
+          <TabToggle />
+        </div>
+      </header>
+
+      {tab === "cities" ? (
+        <section className="space-y-4">
+          <CitySearchForm />
+          <div className="grid gap-3 md:grid-cols-2">
+            {cities.map((c) => <CityCard key={c.id} item={c} />)}
+          </div>
+          <CityTable rows={cities} />
+        </section>
+      ) : (
+        <section className="space-y-4">
+          <div className="text-sm text-gray-600">
+            {process.env.CDP_CORP_BASE ? "Licensed mode active (corporate scores)" : "Corporate scores not configured — showing sample data."}
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {corp.map(s => <CorpCard key={s.id} s={s} />)}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/lib/connectors/cdp/cities_fetch.ts
+++ b/apps/web/src/lib/connectors/cdp/cities_fetch.ts
@@ -1,0 +1,67 @@
+import { CityEmission } from "./types";
+import { transformSocrataRowsToCityEmissions } from "./cities_transform";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_HOST = "https://data.cdp.net";
+
+async function discoverEmissionsDataset(host: string): Promise<string | null> {
+  // Use Socrata Discovery API to find a dataset likely containing citywide emissions.
+  // Example endpoint (server-side only):
+  // https://api.us.socrata.com/api/catalog/v1?domains=data.cdp.net&only=datasets&q=emissions%20inventory&limit=5
+  const discoveryUrl = new URL("https://api.us.socrata.com/api/catalog/v1");
+  discoveryUrl.searchParams.set("domains", host.replace(/^https?:\/\//, ""));
+  discoveryUrl.searchParams.set("search_context", host.replace(/^https?:\/\//, ""));
+  discoveryUrl.searchParams.set("only", "datasets");
+  discoveryUrl.searchParams.set("q", "emissions inventory");
+  discoveryUrl.searchParams.set("limit", "5");
+
+  const res = await fetch(discoveryUrl.toString(), { next: { revalidate: 86400 } });
+  if (!res.ok) return null;
+  const data = await res.json();
+  // Heuristic: pick the first dataset whose columns include a likely total emissions field.
+  const datasets = data?.results || [];
+  for (const d of datasets) {
+    const id = d?.resource?.id;
+    const cols: string[] = (d?.resource?.columns_field_name || []).map((s: string) => s.toLowerCase());
+    if (id && cols.some(c => /total.*emission|city.*emission|tco2e/.test(c))) return id;
+  }
+  return datasets?.[0]?.resource?.id ?? null;
+}
+
+export async function findCityEmissions(params: { city?: string; country?: string; fromYear?: number; toYear?: number; limit?: number; }): Promise<CityEmission[]> {
+  const host = process.env.CDP_SOCRATA_HOST || DEFAULT_HOST;
+  const appToken = process.env.CDP_SODA_APP_TOKEN;
+  const dataset = await discoverEmissionsDataset(host);
+
+  if (dataset) {
+    // Build a permissive SoQL query; we select broad fields and let the transformer normalize.
+    const soda = new URL(`${host}/resource/${dataset}.json`);
+    const limit = String(params.limit ?? 50);
+    soda.searchParams.set("$limit", limit);
+
+    const where: string[] = [];
+    if (params.city) where.push(`upper(city) like upper('${params.city.replace(/'/g,"''")}%')`);
+    if (params.country) where.push(`upper(country) like upper('${params.country.replace(/'/g,"''")}%')`);
+    if (params.fromYear && params.toYear) where.push(`year between ${params.fromYear} and ${params.toYear}`);
+    if (where.length) soda.searchParams.set("$where", where.join(" AND "));
+
+    const headers: Record<string,string> = { "Accept": "application/json" };
+    if (appToken) headers["X-App-Token"] = appToken;
+
+    try {
+      const res = await fetch(soda.toString(), { headers, next: { revalidate: 3600 } });
+      if (res.ok) {
+        const rows = await res.json();
+        const items = transformSocrataRowsToCityEmissions(rows, dataset);
+        if (items.length) return items;
+      }
+    } catch { /* noop */ }
+  }
+
+  // Fallback to sample if discovery or query fails
+  const p = path.join(process.cwd(), "apps/web/public/connectors/cdp/sample-cities.json");
+  const raw = await fs.readFile(p, "utf-8");
+  const sample = JSON.parse(raw);
+  return transformSocrataRowsToCityEmissions(sample, "sample");
+}

--- a/apps/web/src/lib/connectors/cdp/cities_transform.test.ts
+++ b/apps/web/src/lib/connectors/cdp/cities_transform.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { transformSocrataRowsToCityEmissions } from "./cities_transform";
+
+// Ensures variant Socrata field names map correctly to CityEmission
+// so the UI remains robust to schema drift.
+describe("transformSocrataRowsToCityEmissions", () => {
+  it("maps variant field names", () => {
+    const rows = [
+      { city_name: "London", country_name: "United Kingdom", reporting_year: "2021", total_emissions: "123", per_capita_emissions: "3.2" }
+    ];
+    const res = transformSocrataRowsToCityEmissions(rows, "sample");
+    expect(res[0]).toMatchObject({
+      city: "London",
+      country: "United Kingdom",
+      year: 2021,
+      totalEmissionsTCO2e: 123,
+      perCapitaTCO2e: 3.2,
+      sourceDataset: "sample"
+    });
+  });
+});

--- a/apps/web/src/lib/connectors/cdp/cities_transform.ts
+++ b/apps/web/src/lib/connectors/cdp/cities_transform.ts
@@ -1,0 +1,38 @@
+import { CityEmission } from "./types";
+
+export function transformSocrataRowsToCityEmissions(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rows: any[],
+  dataset: string
+): CityEmission[] {
+  if (!Array.isArray(rows)) return [];
+  return rows.map((r, idx) => {
+    // Flexible mapping across common schemas
+    const city = r.city || r.city_name || r.municipality || r.local_government || "";
+    const country = r.country || r.country_name || r.nation || r.state_country || undefined;
+    const year = Number(r.year || r.reporting_year || r.inventory_year || r.calendar_year || NaN);
+    const total =
+      num(r.total_emissions) ?? num(r.total_emissions_tco2e) ?? num(r.citywide_emissions) ??
+      num(r.total_co2e) ?? num(r.total) ?? undefined;
+    const perCap = num(r.per_capita_emissions) ?? num(r.per_capita_tco2e) ?? undefined;
+    const scope = r.scope || r.inventory_scope || r.boundary || undefined;
+    const method = r.inventory_method || r.methodology || r.protocol || undefined;
+
+    return {
+      id: String(r._id || r.id || `${dataset}-${idx}`),
+      city: String(city || "").trim(),
+      country: country ? String(country) : undefined,
+      year: isFinite(year) ? year : undefined,
+      totalEmissionsTCO2e: total,
+      perCapitaTCO2e: perCap,
+      scope,
+      inventoryMethod: method,
+      sourceDataset: dataset
+    } as CityEmission;
+  }).filter(x => x.city);
+}
+
+function num(v: unknown): number | undefined {
+  const n = typeof v === "string" ? Number(v.replace(/,/g,"")) : typeof v === "number" ? v : NaN;
+  return isFinite(n) ? n : undefined;
+}

--- a/apps/web/src/lib/connectors/cdp/corp_fetch.ts
+++ b/apps/web/src/lib/connectors/cdp/corp_fetch.ts
@@ -1,0 +1,34 @@
+import { CorpScore } from "./types";
+import { transformCorpRows } from "./corp_transform";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export async function getCorpScores(params: { company?: string; year?: number; theme?: string; limit?: number; }): Promise<CorpScore[]> {
+  const base = process.env.CDP_CORP_BASE;
+  const key = process.env.CDP_CORP_API_KEY;
+
+  if (base && key) {
+    const url = new URL("/scores", base);
+    if (params.company) url.searchParams.set("company", params.company);
+    if (params.year) url.searchParams.set("year", String(params.year));
+    if (params.theme) url.searchParams.set("theme", String(params.theme));
+    if (params.limit) url.searchParams.set("limit", String(params.limit));
+
+    try {
+      const res = await fetch(url.toString(), {
+        headers: { "Authorization": `Bearer ${key}`, "Accept": "application/json" },
+        next: { revalidate: 3600 }
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const items = transformCorpRows(data);
+        if (items.length) return items;
+      }
+    } catch { /* noop */ }
+  }
+
+  // Fallback
+  const p = path.join(process.cwd(), "apps/web/public/connectors/cdp/sample-corporate.json");
+  const raw = await fs.readFile(p, "utf-8");
+  return transformCorpRows(JSON.parse(raw));
+}

--- a/apps/web/src/lib/connectors/cdp/corp_transform.ts
+++ b/apps/web/src/lib/connectors/cdp/corp_transform.ts
@@ -1,0 +1,18 @@
+import { CorpScore } from "./types";
+
+export function transformCorpRows(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rows: any[]
+): CorpScore[] {
+  if (!Array.isArray(rows)) return [];
+  return rows.map((r, i) => ({
+    id: String(r.id || r.company || i),
+    company: r.company ?? "",
+    year: Number(r.year ?? r.reporting_year ?? new Date().getFullYear()),
+    theme: (String(r.theme || "climate").toLowerCase() as CorpScore["theme"]),
+    score: String(r.score || r.grade || "-").toUpperCase(),
+    country: r.country ?? r.hq_country ?? undefined,
+    isin: r.isin ?? undefined,
+    ticker: r.ticker ?? undefined,
+  })).filter(x => x.company);
+}

--- a/apps/web/src/lib/connectors/cdp/types.ts
+++ b/apps/web/src/lib/connectors/cdp/types.ts
@@ -1,0 +1,22 @@
+export type CityEmission = {
+  id: string;
+  city: string;
+  country?: string;
+  year?: number;
+  scope?: string;            // e.g., "City-wide", "Community"
+  totalEmissionsTCO2e?: number;
+  perCapitaTCO2e?: number;
+  inventoryMethod?: string;
+  sourceDataset?: string;    // Socrata dataset id
+};
+
+export type CorpScore = {
+  id: string;                // company id or name slug
+  company: string;
+  year: number;
+  theme: "climate" | "water" | "forests";
+  score: string;             // e.g., A, A-, B, etc.
+  country?: string;
+  isin?: string;
+  ticker?: string;
+};

--- a/changelog/add-cdp-connector-ui.md
+++ b/changelog/add-cdp-connector-ui.md
@@ -1,0 +1,1 @@
+feat: add CDP connector UI


### PR DESCRIPTION
## Summary
- add `/connectors/cdp` route with search and tab UI
- fetch city emissions from CDP Socrata API with sample fallback
- display licensed corporate scores when configured, with sample fallback otherwise

## Testing
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test`

## Manual verification
- `pnpm -C apps/web dev` → open http://localhost:3000/connectors/cdp
- Try city queries: “London”, “Paris”, “São Paulo”
- Temporarily set invalid `CDP_SOCRATA_HOST` to confirm sample fallback
- Without `CDP_CORP_BASE` confirm “not configured” state shows sample
- With `CDP_SODA_APP_TOKEN` verify rate limits improve

## Compliance
- Cities tab uses CDP Open Data Portal via Socrata APIs
- Corporate tab is license‑gated; sample data used when `CDP_CORP_BASE` unset

------
https://chatgpt.com/codex/tasks/task_e_68be2381137c832194c5d521b037b9e7