### PR TITLE
feat(web): add TCO Certified connector UI page

### DIFF
--- a/apps/web/public/connectors/tco/sample.json
+++ b/apps/web/public/connectors/tco/sample.json
@@ -1,0 +1,41 @@
+{
+  "items": [
+    {
+      "id": "D1025050157",
+      "productType": "Display",
+      "brand": "AOC",
+      "model": "27E4U",
+      "generation": "Gen 10",
+      "certificateNumber": "D1025050157",
+      "certifiedSince": "2025-05-19",
+      "validUntil": "2027-05-19",
+      "gtin": "6921732799999",
+      "detailUrl": "https://tcocertified.com/product-finder/",
+      "certificateUrl": "https://aoc.com/api/download/22551"
+    },
+    {
+      "id": "Q27P4U",
+      "productType": "Display",
+      "brand": "AOC",
+      "model": "Q27P4U",
+      "generation": "Gen 10",
+      "certificateNumber": "D1025070175",
+      "certifiedSince": "2025-07-10",
+      "validUntil": "2027-07-10",
+      "gtin": "6921732700000",
+      "detailUrl": "https://tcocertified.com/product-finder/",
+      "certificateUrl": "https://aoc.com/api/download/23216"
+    },
+    {
+      "id": "GTIN-735007XXXXXX",
+      "productType": "Notebook",
+      "brand": "ExampleBrand",
+      "model": "NB-14 ECO",
+      "generation": "Gen 10",
+      "certifiedSince": "2024-12-12",
+      "validUntil": "2026-12-12",
+      "gtin": "7350071234567",
+      "detailUrl": "https://tcocertified.com/product-finder/"
+    }
+  ]
+}

--- a/apps/web/src/app/connectors/tco/components/Filters.tsx
+++ b/apps/web/src/app/connectors/tco/components/Filters.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+const options = [
+  'All',
+  'Display',
+  'Notebook',
+  'Tablet',
+  'Desktop',
+  'All-in-One PC',
+  'Smartphone',
+  'Headset',
+  'Projector',
+  'Server',
+  'Data Center',
+];
+
+type Props = { selected?: string };
+
+// Dropdown filter for product type categories.
+export default function Filters({ selected = 'All' }: Props) {
+  const router = useRouter();
+  const params = useSearchParams();
+
+  const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    const next = new URLSearchParams(params.toString());
+    if (value && value !== 'All') next.set('type', value);
+    else next.delete('type');
+    router.push(`/connectors/tco?${next.toString()}`);
+  };
+
+  return (
+    <div className="mt-4">
+      <label htmlFor="tco-type" className="mr-2 font-medium">
+        Product type
+      </label>
+      <select
+        id="tco-type"
+        value={selected}
+        onChange={onChange}
+        className="rounded-md border px-2 py-1"
+      >
+        {options.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/web/src/app/connectors/tco/components/ResultCard.tsx
+++ b/apps/web/src/app/connectors/tco/components/ResultCard.tsx
@@ -1,0 +1,50 @@
+import { TcoProduct } from '@/src/lib/connectors/tco/types';
+
+// Card view for an individual TCO Certified product.
+export default function ResultCard({ item }: { item: TcoProduct }) {
+  const name = [item.brand, item.model].filter(Boolean).join(' ') || item.id;
+  const gtinOnly = !item.brand && !item.model && !!item.gtin;
+
+  return (
+    <div className="rounded-md border p-4 text-sm">
+      <h3 className="mb-1 text-base font-semibold">{name}</h3>
+      {item.productType && <p className="mb-2 text-gray-600">{item.productType}</p>}
+      <div className="mb-2 flex flex-wrap gap-1">
+        {item.generation && (
+          <span className="rounded bg-gray-100 px-1 text-xs">{item.generation}</span>
+        )}
+        {item.certificateNumber && (
+          <span className="rounded bg-gray-100 px-1 text-xs">#{item.certificateNumber}</span>
+        )}
+        {item.certifiedSince && item.validUntil && (
+          <span className="rounded bg-gray-100 px-1 text-xs">
+            {item.certifiedSince} → {item.validUntil}
+          </span>
+        )}
+        {gtinOnly && <span className="rounded bg-gray-100 px-1 text-xs">GTIN only</span>}
+      </div>
+      <div className="flex flex-wrap gap-2 text-sm">
+        {item.detailUrl && (
+          <a
+            href={item.detailUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            Open in Product Finder
+          </a>
+        )}
+        {item.certificateUrl && (
+          <a
+            href={item.certificateUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline"
+          >
+            Certificate PDF
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/connectors/tco/components/ResultTable.tsx
+++ b/apps/web/src/app/connectors/tco/components/ResultTable.tsx
@@ -1,0 +1,60 @@
+import { TcoProduct } from '@/src/lib/connectors/tco/types';
+
+// Compact table view of TCO Certified products.
+export default function ResultTable({ items }: { items: TcoProduct[] }) {
+  if (items.length === 0) return <p className="mt-4 text-sm">No results.</p>;
+  return (
+    <table className="mt-8 w-full text-sm">
+      <thead>
+        <tr className="border-b text-left">
+          <th className="p-2">Product</th>
+          <th className="p-2">Type</th>
+          <th className="p-2">Gen</th>
+          <th className="p-2">Cert #</th>
+          <th className="p-2">Since</th>
+          <th className="p-2">Until</th>
+          <th className="p-2">GTIN</th>
+          <th className="p-2">Links</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((item) => {
+          const name = [item.brand, item.model].filter(Boolean).join(' ') || item.id;
+          return (
+            <tr key={item.id} className="border-b last:border-0">
+              <td className="p-2">{name}</td>
+              <td className="p-2">{item.productType}</td>
+              <td className="p-2">{item.generation}</td>
+              <td className="p-2">{item.certificateNumber}</td>
+              <td className="p-2">{item.certifiedSince}</td>
+              <td className="p-2">{item.validUntil}</td>
+              <td className="p-2">{item.gtin}</td>
+              <td className="p-2 space-x-2">
+                {item.detailUrl && (
+                  <a
+                    href={item.detailUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 underline"
+                  >
+                    Detail
+                  </a>
+                )}
+                {item.certificateUrl && (
+                  <a
+                    href={item.certificateUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 underline"
+                  >
+                    PDF
+                  </a>
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/web/src/app/connectors/tco/components/SearchBar.tsx
+++ b/apps/web/src/app/connectors/tco/components/SearchBar.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useState } from 'react';
+import { Button } from '@/src/components/ui/button';
+
+type Props = { defaultValue?: string };
+
+// Controlled search input that syncs with the query string.
+export default function SearchBar({ defaultValue = '' }: Props) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [q, setQ] = useState(defaultValue);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const next = new URLSearchParams(params.toString());
+    if (q.trim()) next.set('q', q.trim());
+    else next.delete('q');
+    router.push(`/connectors/tco?${next.toString()}`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex w-full max-w-md gap-2" aria-label="Search TCO products">
+      <label htmlFor="tco-search" className="sr-only">
+        Search TCO products
+      </label>
+      <input
+        id="tco-search"
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        className="flex-1 rounded-md border px-3 py-2"
+        placeholder="Search by brand, model, GTIN..."
+      />
+      <Button type="submit">Search</Button>
+    </form>
+  );
+}

--- a/apps/web/src/app/connectors/tco/loading.tsx
+++ b/apps/web/src/app/connectors/tco/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p className="p-4">Loading TCO Certified…</p>;
+}

--- a/apps/web/src/app/connectors/tco/page.tsx
+++ b/apps/web/src/app/connectors/tco/page.tsx
@@ -1,0 +1,32 @@
+import SearchBar from './components/SearchBar';
+import Filters from './components/Filters';
+import ResultCard from './components/ResultCard';
+import ResultTable from './components/ResultTable';
+import { searchTcoProducts } from '@/src/lib/connectors/tco/fetch';
+
+export const revalidate = 86400;
+
+interface Props {
+  searchParams: { q?: string; type?: string };
+}
+
+// Server-rendered page listing TCO Certified products.
+export default async function TcoPage({ searchParams }: Props) {
+  const q = typeof searchParams.q === 'string' ? searchParams.q : undefined;
+  const type = typeof searchParams.type === 'string' ? searchParams.type : undefined;
+  const items = await searchTcoProducts(q, type && type !== 'All' ? type : undefined);
+
+  return (
+    <main className="p-4">
+      <h1 className="mb-4 text-2xl font-semibold">TCO Certified Products</h1>
+      <SearchBar defaultValue={q ?? ''} />
+      <Filters selected={type ?? 'All'} />
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {items.map((item) => (
+          <ResultCard key={item.id} item={item} />
+        ))}
+      </div>
+      <ResultTable items={items} />
+    </main>
+  );
+}

--- a/apps/web/src/app/connectors/tco/transform.test.ts
+++ b/apps/web/src/app/connectors/tco/transform.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { transformTcoRecord } from '../../../lib/connectors/tco/transform';
+
+describe('transformTcoRecord', () => {
+  it('maps json-ld styled record', () => {
+    const rec = {
+      '@id': 'https://example.com/gtin/12345',
+      '@type': 'Display',
+      brand: { name: 'Brand' },
+      model: 'ModelX',
+      certificateNumber: 'C123',
+    };
+    const product = transformTcoRecord(rec);
+    expect(product).toMatchObject({ id: '12345', brand: 'Brand', model: 'ModelX', certificateNumber: 'C123' });
+  });
+
+  it('tolerates GTIN-only shape', () => {
+    const product = transformTcoRecord({ gtin: '987654321' });
+    expect(product).toMatchObject({ id: '987654321', gtin: '987654321' });
+  });
+
+  it('preserves certificate number', () => {
+    const product = transformTcoRecord({ certificate_number: 'XYZ' });
+    expect(product?.certificateNumber).toBe('XYZ');
+  });
+});

--- a/apps/web/src/lib/connectors/tco/fetch.ts
+++ b/apps/web/src/lib/connectors/tco/fetch.ts
@@ -1,0 +1,99 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { TcoProduct, TcoSearchResponse } from './types';
+import { transformTcoRecord } from './transform';
+
+const DEFAULT_BASE = 'https://api.tcocertified.com';
+
+async function fetchToken(): Promise<string | null> {
+  const user = process.env.TCO_API_USER;
+  const key = process.env.TCO_API_KEY;
+  const base = process.env.TCO_API_BASE || DEFAULT_BASE;
+  if (!user || !key) return null;
+  try {
+    const init: RequestInit & { next: { revalidate: number } } = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ username: user, password: key }),
+      next: { revalidate: 86400 },
+    };
+    const res = await fetch(`${base}/token`, init);
+    if (!res.ok) return null;
+    const data = (await res.json()) as { token?: string };
+    return data.token || null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchGtinList(token: string | null, productType?: string): Promise<TcoProduct[]> {
+  const base = process.env.TCO_API_BASE || DEFAULT_BASE;
+  try {
+    const url = new URL(`${base}/generic/gtin`);
+    url.searchParams.set('page', '1');
+    if (productType) url.searchParams.set('product_type', productType);
+    if (process.env.TCO_API_USE_JSONLD === 'true') url.searchParams.set('jsonld', 'true');
+    const init: RequestInit & { next: { revalidate: number } } = {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        ...(token ? { 'X-Auth-Token': `Bearer ${token}` } : {}),
+      },
+      next: { revalidate: 86400 },
+    };
+    const res = await fetch(url.toString(), init);
+    if (!res.ok) return [];
+    const data: unknown = await res.json();
+    const record = (data as Record<string, unknown>) || {};
+    const list = Array.isArray(data)
+      ? data
+      : (record.items as unknown[]) ||
+        (record.results as unknown[]) ||
+        (record.data as unknown[]) ||
+        [];
+    return (list as unknown[])
+      .map((r) => transformTcoRecord(r))
+      .filter((p): p is TcoProduct => p !== null);
+  } catch {
+    return [];
+  }
+}
+
+async function loadSample(productType?: string): Promise<TcoProduct[]> {
+  try {
+    const samplePath = path.join(process.cwd(), 'public/connectors/tco/sample.json');
+    const raw = await fs.readFile(samplePath, 'utf8');
+    const data = JSON.parse(raw) as TcoSearchResponse;
+    let items = Array.isArray(data.items) ? data.items : [];
+    if (productType) {
+      const type = productType.toLowerCase();
+      items = items.filter((i) => i.productType?.toLowerCase() === type);
+    }
+    return items;
+  } catch {
+    return [];
+  }
+}
+
+export async function searchTcoProducts(q: string | undefined, productType?: string): Promise<TcoProduct[]> {
+  let items: TcoProduct[] = [];
+  const token = await fetchToken();
+  if (token) {
+    items = await fetchGtinList(token, productType);
+  }
+  if (!token || items.length === 0) {
+    items = await loadSample(productType);
+  }
+  if (q) {
+    const qLower = q.toLowerCase();
+    items = items.filter((i) =>
+      [i.brand, i.model, i.gtin, i.certificateNumber].some((f) =>
+        f?.toLowerCase().includes(qLower)
+      )
+    );
+  }
+  return items;
+}

--- a/apps/web/src/lib/connectors/tco/transform.ts
+++ b/apps/web/src/lib/connectors/tco/transform.ts
@@ -1,0 +1,60 @@
+import { TcoProduct, TcoGtinRecord } from './types';
+
+export function transformTcoRecord(r: TcoGtinRecord): TcoProduct | null {
+  if (!r) return null;
+
+  // Try common shapes; tolerate JSON-LD and flat JSON.
+  const gtin = String(
+    r.gtin || r.GTIN || r.id || r['@id']?.toString().split('/').pop() || ''
+  ).trim();
+
+  const productType =
+    r.product_type || r.productType || r.category || r['@type'] || undefined;
+
+  const brand =
+    r.brand?.name || r.brand || r.manufacturer || undefined;
+
+  const model =
+    r.model || r.modelName || r.name || undefined;
+
+  const certificateNumber =
+    r.certificateNumber || r.certificate_number || undefined;
+
+  const generation =
+    r.generation || r.tcoGeneration || undefined;
+
+  const certifiedSince =
+    r.certifiedSince || r.certification_date || r.validFrom || undefined;
+
+  const validUntil =
+    r.validUntil || r.valid_to || r.expires || undefined;
+
+  const detailUrl =
+    r.detailUrl || r.detail_url || r.productFinderUrl || undefined;
+
+  const certificateUrl =
+    r.certificateUrl || r.certificate_url || undefined;
+
+  const id =
+    gtin ||
+    certificateNumber ||
+    [brand, model].filter(Boolean).join(' ') ||
+    (typeof productType === 'string' ? productType : '') ||
+    '';
+
+  if (!id) return null;
+
+  return {
+    id,
+    productType: typeof productType === 'string' ? productType : undefined,
+    brand: typeof brand === 'string' ? brand : undefined,
+    model: typeof model === 'string' ? model : undefined,
+    generation: typeof generation === 'string' ? generation : undefined,
+    certificateNumber: typeof certificateNumber === 'string' ? certificateNumber : undefined,
+    certifiedSince: typeof certifiedSince === 'string' ? certifiedSince : undefined,
+    validUntil: typeof validUntil === 'string' ? validUntil : undefined,
+    gtin: gtin || undefined,
+    detailUrl: typeof detailUrl === 'string' ? detailUrl : undefined,
+    certificateUrl: typeof certificateUrl === 'string' ? certificateUrl : undefined,
+  };
+}

--- a/apps/web/src/lib/connectors/tco/types.ts
+++ b/apps/web/src/lib/connectors/tco/types.ts
@@ -1,0 +1,18 @@
+export type TcoProduct = {
+  id: string;                 // gtin || certificateNumber || slug
+  productType?: string;       // e.g., "Display", "Notebook"
+  brand?: string;
+  model?: string;
+  generation?: string;        // e.g., "Gen 10"
+  certificateNumber?: string; // e.g., D1025050157
+  certifiedSince?: string;    // ISO date
+  validUntil?: string;        // ISO date
+  gtin?: string;
+  detailUrl?: string;         // Product Finder detail
+  certificateUrl?: string;    // PDF if known
+};
+
+export type TcoApiTokenResponse = { result?: string; token?: string; validUntil?: string };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TcoGtinRecord = any;     // API payload is not guaranteed; treat defensively
+export type TcoSearchResponse = { items: TcoProduct[] };

--- a/changelog/feat-connector-tco-ui.md
+++ b/changelog/feat-connector-tco-ui.md
@@ -1,0 +1,1 @@
+feat(tco): add TCO Certified connector UI page


### PR DESCRIPTION
## Summary
- add isolated /connectors/tco route with search, filters, cards and table views
- include optional GTIN API fetch with token auth and sample fallback
- document transformer tests and changelog entry

## Testing
- `pnpm -C apps/web test`
- `pnpm -C apps/web build`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68be2393228883219de65fd1ba1da114