### PR TITLE
feat: add iFixit connector UI page

### DIFF
--- a/apps/web/app/connectors/ifixit/components/GuideCard.tsx
+++ b/apps/web/app/connectors/ifixit/components/GuideCard.tsx
@@ -1,0 +1,30 @@
+import { Card } from '@/src/components/ui/card';
+import { Badge } from '@/src/components/ui/badge';
+import type { IfixitGuideDetail } from '@/src/lib/connectors/ifixit/types';
+
+// Displays an enriched repair guide with basic repairability signals.
+export default function GuideCard({ guide }: { guide: IfixitGuideDetail }) {
+  const img = guide.image?.standard || guide.image?.medium || guide.image?.large;
+  return (
+    <Card className="flex flex-col gap-2">
+      {img && <img src={img} alt={guide.title} className="h-40 w-full rounded object-cover" />}
+      <h3 className="text-sm font-semibold">{guide.title}</h3>
+      {guide.category && <p className="text-xs text-gray-600">{guide.category}</p>}
+      <div className="flex flex-wrap gap-1">
+        {guide.difficulty && <Badge>Difficulty: {guide.difficulty}</Badge>}
+        {guide.time_required && <Badge>{guide.time_required}</Badge>}
+        <Badge>Steps: {guide.stepsCount}</Badge>
+        <Badge>Parts: {guide.partsCount}</Badge>
+        <Badge>Tools: {guide.toolsCount}</Badge>
+      </div>
+      <a
+        href={guide.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-sm text-blue-600 underline"
+      >
+        View on iFixit
+      </a>
+    </Card>
+  );
+}

--- a/apps/web/app/connectors/ifixit/components/SearchBar.tsx
+++ b/apps/web/app/connectors/ifixit/components/SearchBar.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import { Button } from '@/src/components/ui/button';
+
+// Input bar for querying the iFixit API. Lives client-side so users can change
+// the query without a full page reload; actual fetching remains server-side.
+export default function SearchBar() {
+  const searchParams = useSearchParams();
+  const [q, setQ] = useState(searchParams.get('q') ?? '');
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const query = q.trim();
+    startTransition(() => {
+      router.replace(`/connectors/ifixit?q=${encodeURIComponent(query || '')}`);
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex w-full max-w-md gap-2" role="search">
+      <label htmlFor="ifixit-search" className="sr-only">
+        Search iFixit
+      </label>
+      <input
+        id="ifixit-search"
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        className="flex-1 rounded-md border px-3 py-2"
+        placeholder="Search iFixit..."
+      />
+      <Button type="submit" disabled={pending}>Search</Button>
+    </form>
+  );
+}

--- a/apps/web/app/connectors/ifixit/components/WikiCard.tsx
+++ b/apps/web/app/connectors/ifixit/components/WikiCard.tsx
@@ -1,0 +1,22 @@
+import { Card } from '@/src/components/ui/card';
+import type { IfixitSuggestWiki } from '@/src/lib/connectors/ifixit/types';
+
+// Renders an iFixit wiki/device page hit with summary when available.
+export default function WikiCard({ wiki }: { wiki: IfixitSuggestWiki }) {
+  const img = wiki.image?.standard || wiki.image?.medium || wiki.image?.large;
+  return (
+    <Card className="flex flex-col gap-2">
+      {img && <img src={img} alt={wiki.title} className="h-40 w-full rounded object-cover" />}
+      <h3 className="text-sm font-semibold">{wiki.display_title || wiki.title}</h3>
+      {wiki.summary && <p className="text-xs text-gray-600">{wiki.summary}</p>}
+      <a
+        href={wiki.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-sm text-blue-600 underline"
+      >
+        Open device page
+      </a>
+    </Card>
+  );
+}

--- a/apps/web/app/connectors/ifixit/loading.tsx
+++ b/apps/web/app/connectors/ifixit/loading.tsx
@@ -1,0 +1,4 @@
+// Loading state displayed while the iFixit connector page streams in.
+export default function Loading() {
+  return <p className="p-4 animate-pulse">Loading iFixit…</p>;
+}

--- a/apps/web/app/connectors/ifixit/page.tsx
+++ b/apps/web/app/connectors/ifixit/page.tsx
@@ -1,0 +1,56 @@
+import SearchBar from './components/SearchBar';
+import GuideCard from './components/GuideCard';
+import WikiCard from './components/WikiCard';
+import { searchIfixit, getGuideDetail } from '@/src/lib/connectors/ifixit/fetch';
+import type { IfixitGuideDetail } from '@/src/lib/connectors/ifixit/types';
+
+export const revalidate = 3600;
+
+// Server-rendered page showing iFixit search results and enrichment.
+export default async function IfixitPage({
+  searchParams,
+}: {
+  searchParams: { q?: string };
+}) {
+  const q = searchParams.q ?? 'iphone battery';
+  const search = await searchIfixit(q);
+
+  const guides = (
+    await Promise.all(
+      search.guides.slice(0, 10).map((g) => getGuideDetail(g.guideid)),
+    )
+  ).filter(Boolean) as IfixitGuideDetail[];
+  const wikis = search.wikis.slice(0, 10);
+  const empty = guides.length === 0 && wikis.length === 0;
+
+  return (
+    <main className="mx-auto max-w-4xl space-y-6 p-4">
+      <header className="space-y-1">
+        <h1 className="text-3xl font-bold">iFixit</h1>
+        <p className="text-gray-600">Repair guides and device wikis from iFixit.</p>
+      </header>
+      <SearchBar />
+      {empty && <p className="text-sm text-gray-600">No results found.</p>}
+      {guides.length > 0 && (
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">Guides</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {guides.map((g) => (
+              <GuideCard key={g.guideid} guide={g} />
+            ))}
+          </div>
+        </section>
+      )}
+      {wikis.length > 0 && (
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">Devices & Categories</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {wikis.map((w) => (
+              <WikiCard key={w.url} wiki={w} />
+            ))}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/connectors/ifixit/transform.test.ts
+++ b/apps/web/app/connectors/ifixit/transform.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { transformSuggest, transformGuideDetail } from '../../../src/lib/connectors/ifixit/transform';
+import sampleSuggest from '../../../public/connectors/ifixit/sample_suggest.json';
+import sampleGuide from '../../../public/connectors/ifixit/sample_guide.json';
+
+describe('iFixit transformers', () => {
+  it('splits guides and wikis from suggest', () => {
+    const res = transformSuggest(sampleSuggest);
+    expect(res.guides).toHaveLength(1);
+    expect(res.wikis).toHaveLength(1);
+  });
+
+  it('counts arrays in guide detail', () => {
+    const detail = transformGuideDetail(sampleGuide);
+    expect(detail.stepsCount).toBe(2);
+    expect(detail.partsCount).toBe(1);
+    expect(detail.toolsCount).toBe(1);
+    const minimal = transformGuideDetail({ guideid: 1, title: 't', url: 'u' });
+    expect(minimal.stepsCount).toBe(0);
+  });
+});

--- a/apps/web/public/connectors/ifixit/sample_guide.json
+++ b/apps/web/public/connectors/ifixit/sample_guide.json
@@ -1,0 +1,12 @@
+{
+  "guideid": 12345,
+  "title": "iPhone Battery Replacement",
+  "url": "https://www.ifixit.com/Guide/Example/12345",
+  "category": "iPhone 8",
+  "type": "replacement",
+  "difficulty": "moderate",
+  "time_required": "30 minutes",
+  "steps": [{ "title": "Step 1" }, { "title": "Step 2" }],
+  "parts": [{ "name": "Battery" }],
+  "tools": [{ "name": "Pentalobe Screwdriver" }]
+}

--- a/apps/web/public/connectors/ifixit/sample_suggest.json
+++ b/apps/web/public/connectors/ifixit/sample_suggest.json
@@ -1,0 +1,18 @@
+{
+  "query": "iphone battery",
+  "results": [
+    {
+      "dataType": "guide",
+      "guideid": 12345,
+      "title": "iPhone Battery Replacement",
+      "category": "iPhone 8",
+      "url": "https://www.ifixit.com/Guide/Example/12345"
+    },
+    {
+      "dataType": "wiki",
+      "title": "iPhone 8",
+      "display_title": "iPhone 8 Repair",
+      "url": "https://www.ifixit.com/Device/iPhone_8"
+    }
+  ]
+}

--- a/apps/web/src/lib/connectors/ifixit/fetch.ts
+++ b/apps/web/src/lib/connectors/ifixit/fetch.ts
@@ -7,11 +7,15 @@ const headers = {
   Accept: 'application/json',
 };
 
+// Extend RequestInit so we can use Next.js' revalidate option without type errors.
+type NextFetchOptions = RequestInit & { next?: { revalidate?: number } };
+
 // Queries iFixit for guides and devices. Falls back to bundled samples on error.
 export async function searchIfixit(q: string): Promise<IfixitSearch> {
   const url = `${BASE}/suggest/${encodeURIComponent(q)}?doctypes=guide,device`;
   try {
-    const res = await fetch(url, { headers, next: { revalidate: 3600 } });
+    // Cast to NextFetchOptions to include `next.revalidate` for ISR caching.
+    const res = await fetch(url, { headers, next: { revalidate: 3600 } } as NextFetchOptions);
     if (!res.ok) throw new Error(`status ${res.status}`);
     const json = await res.json();
     return transformSuggest(json);
@@ -26,7 +30,8 @@ export async function searchIfixit(q: string): Promise<IfixitSearch> {
 export async function getGuideDetail(id: number): Promise<IfixitGuideDetail | null> {
   const url = `${BASE}/guides/${id}`;
   try {
-    const res = await fetch(url, { headers, next: { revalidate: 3600 } });
+    // Cast ensures Next.js revalidation option is recognised by TypeScript.
+    const res = await fetch(url, { headers, next: { revalidate: 3600 } } as NextFetchOptions);
     if (!res.ok) throw new Error(`status ${res.status}`);
     const json = await res.json();
     return transformGuideDetail(json);

--- a/apps/web/src/lib/connectors/ifixit/fetch.ts
+++ b/apps/web/src/lib/connectors/ifixit/fetch.ts
@@ -1,0 +1,42 @@
+import { transformGuideDetail, transformSuggest } from './transform';
+import type { IfixitGuideDetail, IfixitSearch } from './types';
+
+const BASE = process.env.IFIXIT_API_BASE ?? 'https://www.ifixit.com/api/2.0';
+const headers = {
+  'User-Agent': 'circl-docs-ui',
+  Accept: 'application/json',
+};
+
+// Queries iFixit for guides and devices. Falls back to bundled samples on error.
+export async function searchIfixit(q: string): Promise<IfixitSearch> {
+  const url = `${BASE}/suggest/${encodeURIComponent(q)}?doctypes=guide,device`;
+  try {
+    const res = await fetch(url, { headers, next: { revalidate: 3600 } });
+    if (!res.ok) throw new Error(`status ${res.status}`);
+    const json = await res.json();
+    return transformSuggest(json);
+  } catch {
+    // Network errors or non-OK responses use sample data for graceful degradation.
+    const sample = (await import('../../../../public/connectors/ifixit/sample_suggest.json')).default;
+    return transformSuggest(sample);
+  }
+}
+
+// Retrieves detailed information for a specific guide.
+export async function getGuideDetail(id: number): Promise<IfixitGuideDetail | null> {
+  const url = `${BASE}/guides/${id}`;
+  try {
+    const res = await fetch(url, { headers, next: { revalidate: 3600 } });
+    if (!res.ok) throw new Error(`status ${res.status}`);
+    const json = await res.json();
+    return transformGuideDetail(json);
+  } catch {
+    // Fallback sample ensures UI still renders basic guide info.
+    try {
+      const sample = (await import('../../../../public/connectors/ifixit/sample_guide.json')).default;
+      return transformGuideDetail(sample);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/apps/web/src/lib/connectors/ifixit/transform.ts
+++ b/apps/web/src/lib/connectors/ifixit/transform.ts
@@ -1,0 +1,84 @@
+import type {
+  IfixitImage,
+  IfixitSuggestGuide,
+  IfixitSuggestWiki,
+  IfixitGuideDetail,
+  IfixitSearch,
+} from './types';
+
+// Coerces an arbitrary object with iFixit image fields into a typed image map.
+// Undefined is returned when no known sizes exist to keep consumers simple.
+export function coerceImage(obj: unknown): IfixitImage | undefined {
+  if (!obj || typeof obj !== 'object') return undefined;
+  const source = obj as Record<string, unknown>;
+  const image: IfixitImage = {};
+  const keys = ['thumbnail', 'mini', 'medium', 'large', 'standard', 'huge', 'original'] as const;
+  let found = false;
+  for (const k of keys) {
+    const v = source[k];
+    if (typeof v === 'string') {
+      (image as Record<string, string>)[k] = v;
+      found = true;
+    }
+  }
+  return found ? image : undefined;
+}
+
+// Splits raw suggest results into guides and wikis, discarding unknown shapes.
+export function transformSuggest(json: unknown): IfixitSearch {
+  const guides: IfixitSuggestGuide[] = [];
+  const wikis: IfixitSuggestWiki[] = [];
+  const data = (json as { results?: unknown[] }).results;
+  if (Array.isArray(data)) {
+    for (const r of data) {
+      const item = r as Record<string, unknown>;
+      const type = item['dataType'];
+      if (
+        type === 'guide' &&
+        typeof item['guideid'] === 'number' &&
+        typeof item['title'] === 'string' &&
+        typeof item['url'] === 'string'
+      ) {
+        guides.push({
+          dataType: 'guide',
+          guideid: item['guideid'] as number,
+          title: item['title'] as string,
+          subject: item['subject'] as string | undefined,
+          category: item['category'] as string | undefined,
+          url: item['url'] as string,
+          image: coerceImage(item['image']),
+        });
+      } else if (type === 'wiki' && typeof item['title'] === 'string' && typeof item['url'] === 'string') {
+        wikis.push({
+          dataType: 'wiki',
+          title: item['title'] as string,
+          display_title: item['display_title'] as string | undefined,
+          url: item['url'] as string,
+          namespace: item['namespace'] as string | undefined,
+          wikiid: item['wikiid'] as number | undefined,
+          image: coerceImage(item['image']),
+          summary: item['summary'] as string | undefined,
+        });
+      }
+    }
+  }
+  return { guides, wikis };
+}
+
+// Normalises detailed guide payload to a concise structure with counts.
+export function transformGuideDetail(json: unknown): IfixitGuideDetail {
+  const data = json as Record<string, unknown>;
+  return {
+    guideid: data['guideid'] as number,
+    title: data['title'] as string,
+    url: data['url'] as string,
+    category: data['category'] as string | undefined,
+    type: data['type'] as string | undefined,
+    difficulty: (data['difficulty'] as string | undefined) ?? null,
+    time_required: (data['time_required'] as string | undefined) ?? null,
+    stepsCount: Array.isArray(data['steps']) ? (data['steps'] as unknown[]).length : 0,
+    partsCount: Array.isArray(data['parts']) ? (data['parts'] as unknown[]).length : 0,
+    toolsCount: Array.isArray(data['tools']) ? (data['tools'] as unknown[]).length : 0,
+    image: coerceImage(data['image']),
+  };
+}

--- a/apps/web/src/lib/connectors/ifixit/types.ts
+++ b/apps/web/src/lib/connectors/ifixit/types.ts
@@ -1,0 +1,54 @@
+// Types for iFixit API results used by the web UI connector.
+// Defined separately to keep fetchers and transformers strongly typed.
+
+export type IfixitImage = {
+  thumbnail?: string;
+  mini?: string;
+  medium?: string;
+  large?: string;
+  standard?: string;
+  huge?: string;
+  original?: string;
+};
+
+export type IfixitSuggestGuide = {
+  dataType: 'guide';
+  guideid: number;
+  title: string;
+  subject?: string;
+  category?: string;
+  url: string;
+  image?: IfixitImage;
+};
+
+export type IfixitSuggestWiki = {
+  dataType: 'wiki';
+  title: string;
+  display_title?: string;
+  url: string;
+  namespace?: string;
+  wikiid?: number;
+  image?: IfixitImage;
+  summary?: string;
+};
+
+export type IfixitSuggestResult = IfixitSuggestGuide | IfixitSuggestWiki;
+
+export type IfixitGuideDetail = {
+  guideid: number;
+  title: string;
+  url: string;
+  category?: string;
+  type?: string;
+  difficulty?: string | null;
+  time_required?: string | null;
+  stepsCount: number;
+  partsCount: number;
+  toolsCount: number;
+  image?: IfixitImage;
+};
+
+export type IfixitSearch = {
+  guides: IfixitSuggestGuide[];
+  wikis: IfixitSuggestWiki[];
+};

--- a/changelog/feat-ifixit-connector-ui-page.md
+++ b/changelog/feat-ifixit-connector-ui-page.md
@@ -1,0 +1,1 @@
+feat: add iFixit connector UI page


### PR DESCRIPTION
## Summary
- add iFixit connector types, fetchers, and transformers with sample fallbacks
- expose server-rendered /connectors/ifixit route with search, guide, and wiki cards
- cover transformer logic with small vitest suite

## Testing
- `pnpm --filter @circl/web lint`
- `pnpm --filter @circl/web test`


------
https://chatgpt.com/codex/tasks/task_e_68be22e7a6488321ac21de80dee6dbbd