### PR TITLE
feat: connectors hub page

### DIFF
--- a/apps/web/app/connectors/_data/connectors.ts
+++ b/apps/web/app/connectors/_data/connectors.ts
@@ -1,0 +1,144 @@
+export type ConnectorMeta = {
+  slug: string; // URL segment for existing connector route
+  title: string; // Human readable connector name
+  summary: string; // Short description for hub card
+  route: string; // Path to existing connector page
+  tags: string[]; // Tags used for filtering in the hub
+  sample?: string; // Example query to display
+  tips: string[]; // Usage tips displayed in expandable section
+  icon?: string; // Optional public path to icon
+};
+
+// Local registry keeps hub self-contained and avoids touching global configs.
+export const CONNECTORS: ConnectorMeta[] = [
+  {
+    slug: "off",
+    title: "Open Food Facts",
+    summary: "Search food products; view Nutri-Score, Eco-Score, NOVA & labels.",
+    route: "/connectors/off",
+    tags: ["products","food","labels"],
+    sample: "Try: oat milk, dark chocolate",
+    tips: [
+      "Type a product name; results show Nutri/Eco scores when available.",
+      "Use precise terms (e.g., “organic oat milk 1L”) for better matches."
+    ],
+    icon: "/connectors/icons/food.svg"
+  },
+  {
+    slug: "ifixit",
+    title: "iFixit",
+    summary: "Repair guides & parts references for devices and appliances.",
+    route: "/connectors/ifixit",
+    tags: ["repair","guides","devices"],
+    sample: "Try: iPhone 12 screen, Dyson v8 battery",
+    tips: [
+      "Search by model name; open a guide to see tools & steps.",
+      "Prefer exact model codes for precise results."
+    ],
+    icon: "/connectors/icons/repair.svg"
+  },
+  {
+    slug: "ebay",
+    title: "eBay (Refurb / Used)",
+    summary: "Discover second-hand & refurb listings to extend product lifecycles.",
+    route: "/connectors/ebay",
+    tags: ["resale","marketplace"],
+    sample: "Try: ThinkPad T14, ‘monitor 27\" refurb’",
+    tips: [
+      "Use specific models plus “refurbished” or “used” in your query.",
+      "Filter inside the page for price and condition if provided."
+    ],
+    icon: "/connectors/icons/market.svg"
+  },
+  {
+    slug: "energystar",
+    title: "ENERGY STAR",
+    summary: "Find energy-efficient appliances and electronics.",
+    route: "/connectors/energystar",
+    tags: ["efficiency","appliances"],
+    sample: "Try: refrigerators, heat pumps",
+    tips: [
+      "Start with a category (e.g., refrigerators).",
+      "Use page filters like capacity or form factor if available."
+    ],
+    icon: "/connectors/icons/energy.svg"
+  },
+  {
+    slug: "tco",
+    title: "TCO Certified",
+    summary: "IT products meeting sustainability criteria (social & environmental).",
+    route: "/connectors/tco",
+    tags: ["certification","it"],
+    sample: "Try: monitors 27\", laptops",
+    tips: [
+      "Begin with a product category (e.g., displays).",
+      "Look for model-specific certificates."
+    ],
+    icon: "/connectors/icons/cert.svg"
+  },
+  {
+    slug: "eu-ecolabel",
+    title: "EU Ecolabel (Products)",
+    summary: "Products meeting EU Ecolabel criteria across many categories.",
+    route: "/connectors/eu-ecolabel",
+    tags: ["certification","consumer"],
+    sample: "Try: detergents, tissue paper",
+    tips: [
+      "Search by category or brand.",
+      "Use generic terms first, then narrow."
+    ],
+    icon: "/connectors/icons/leaf.svg"
+  },
+  {
+    slug: "green-seal",
+    title: "Green Seal",
+    summary: "Green Seal certified products (cleaners, paper, more).",
+    route: "/connectors/green-seal",
+    tags: ["certification","cleaning"],
+    sample: "Try: all-purpose cleaner",
+    tips: [
+      "Start with a product type (e.g., ‘glass cleaner’).",
+      "Brand names can help refine."
+    ],
+    icon: "/connectors/icons/leaf.svg"
+  },
+  {
+    slug: "fairtrade",
+    title: "Fairtrade Product Finder",
+    summary: "Spot products carrying the Fairtrade Mark.",
+    route: "/connectors/fairtrade",
+    tags: ["ethical","food","beverage"],
+    sample: "Try: chocolate, coffee beans",
+    tips: [
+      "Search by product type; country/brand filters if available.",
+      "Short queries work well (e.g., ‘coffee’)."
+    ],
+    icon: "/connectors/icons/fair.svg"
+  },
+  {
+    slug: "lot-uk",
+    title: "Library of Things (UK)",
+    summary: "Borrow items locally instead of buying.",
+    route: "/connectors/lot-uk",
+    tags: ["borrow","local","uk"],
+    sample: "Try: postcode + item (e.g., NW1 8AH drill)",
+    tips: [
+      "Enter your UK postcode and the thing you need.",
+      "Check item availability and pickup location."
+    ],
+    icon: "/connectors/icons/borrow.svg"
+  },
+  {
+    slug: "cdp",
+    title: "CDP (Carbon Disclosure Project)",
+    summary: "Company climate disclosures and scores.",
+    route: "/connectors/cdp",
+    tags: ["companies","climate","esg"],
+    sample: "Try: Unilever, Tesco",
+    tips: [
+      "Search by company name.",
+      "Use full legal names for best results."
+    ],
+    icon: "/connectors/icons/company.svg"
+  }
+];

--- a/apps/web/app/connectors/components/ConnectorCard.tsx
+++ b/apps/web/app/connectors/components/ConnectorCard.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import TagPill from "./TagPill";
+import type { ConnectorMeta } from "../_data/connectors";
+
+// Card summarising a connector with tips and navigation link.
+export default function ConnectorCard({ c }: { c: ConnectorMeta }) {
+  return (
+    <article className="rounded-2xl border p-4 flex gap-4">
+      {c.icon ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={c.icon} alt="" className="w-10 h-10 mt-1 opacity-80" />
+      ) : <div className="w-10 h-10" />}
+      <div className="flex-1 space-y-2">
+        <header>
+          <h3 className="text-lg font-semibold">{c.title}</h3>
+          <p className="text-sm text-gray-600">{c.summary}</p>
+        </header>
+        <div className="flex flex-wrap gap-1">
+          {c.tags.map(t => <TagPill key={t}>{t}</TagPill>)}
+        </div>
+        <details className="text-sm">
+          <summary className="cursor-pointer select-none">How to use</summary>
+          <ul className="list-disc ml-5 mt-1 space-y-1">
+            {c.tips.map((t, i) => <li key={i}>{t}</li>)}
+          </ul>
+          {c.sample && <p className="mt-2 italic">Example: {c.sample}</p>}
+        </details>
+        <div className="pt-2">
+          <Link
+            href={c.route}
+            className="inline-block px-3 py-1.5 rounded-md border shadow-sm text-sm"
+          >
+            Open {c.title}
+          </Link>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/apps/web/app/connectors/components/ConnectorCard.tsx
+++ b/apps/web/app/connectors/components/ConnectorCard.tsx
@@ -7,7 +7,6 @@ export default function ConnectorCard({ c }: { c: ConnectorMeta }) {
   return (
     <article className="rounded-2xl border p-4 flex gap-4">
       {c.icon ? (
-        // eslint-disable-next-line @next/next/no-img-element
         <img src={c.icon} alt="" className="w-10 h-10 mt-1 opacity-80" />
       ) : <div className="w-10 h-10" />}
       <div className="flex-1 space-y-2">

--- a/apps/web/app/connectors/components/SearchAndFilter.tsx
+++ b/apps/web/app/connectors/components/SearchAndFilter.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useMemo, useState } from "react";
+import type { ConnectorMeta } from "../_data/connectors";
+
+// Client component handles search + tag filtering without server roundtrips.
+export default function SearchAndFilter({ items, onFiltered }:{
+  items: ConnectorMeta[];
+  onFiltered: (xs: ConnectorMeta[]) => void;
+}) {
+  const allTags = useMemo(() => Array.from(new Set(items.flatMap(i => i.tags))).sort(), [items]);
+  const [q, setQ] = useState("");
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const apply = (query: string, tags: string[]) => {
+    const qNorm = query.toLowerCase();
+    const filtered = items.filter(i => {
+      const text = (i.title + " " + i.summary + " " + i.tags.join(" ")).toLowerCase();
+      const hitQ = !qNorm || text.includes(qNorm);
+      const hitTags = tags.length === 0 || tags.every(t => i.tags.includes(t));
+      return hitQ && hitTags;
+    });
+    onFiltered(filtered);
+  };
+
+  return (
+    <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <input
+        value={q}
+        onChange={(e)=>{ setQ(e.target.value); apply(e.target.value, selected); }}
+        placeholder="Search connectors…"
+        className="px-3 py-2 rounded-md border w-full md:w-96"
+        aria-label="Search connectors"
+      />
+      <div className="flex gap-2 flex-wrap">
+        {allTags.map(t => {
+          const active = selected.includes(t);
+          return (
+            <button
+              key={t}
+              type="button"
+              onClick={()=>{
+                const next = active ? selected.filter(x=>x!==t) : [...selected, t];
+                setSelected(next); apply(q, next);
+              }}
+              className={`text-xs px-2 py-1 rounded-full border ${active ? "bg-gray-900 text-white" : "bg-gray-50"}`}
+              aria-pressed={active}
+            >
+              {t}
+            </button>
+          );
+        })}
+        {selected.length > 0 && (
+          <button
+            type="button"
+            onClick={()=>{ setSelected([]); apply(q, []); }}
+            className="text-xs px-2 py-1 rounded-full border"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/connectors/components/SearchAndFilter.tsx
+++ b/apps/web/app/connectors/components/SearchAndFilter.tsx
@@ -1,64 +1,85 @@
 "use client";
 import { useMemo, useState } from "react";
 import type { ConnectorMeta } from "../_data/connectors";
+import ConnectorCard from "./ConnectorCard";
 
-// Client component handles search + tag filtering without server roundtrips.
-export default function SearchAndFilter({ items, onFiltered }:{
-  items: ConnectorMeta[];
-  onFiltered: (xs: ConnectorMeta[]) => void;
-}) {
-  const allTags = useMemo(() => Array.from(new Set(items.flatMap(i => i.tags))).sort(), [items]);
+// Renders search and tag filters with a client-side list of connector cards.
+// This component owns the filtered state so the server page stays static.
+export default function SearchAndFilter({ items }: { items: ConnectorMeta[] }) {
+  const allTags = useMemo(
+    () => Array.from(new Set(items.flatMap(i => i.tags))).sort(),
+    [items]
+  );
   const [q, setQ] = useState("");
   const [selected, setSelected] = useState<string[]>([]);
+  const [filtered, setFiltered] = useState<ConnectorMeta[]>(items);
 
   const apply = (query: string, tags: string[]) => {
     const qNorm = query.toLowerCase();
-    const filtered = items.filter(i => {
+    const next = items.filter(i => {
       const text = (i.title + " " + i.summary + " " + i.tags.join(" ")).toLowerCase();
       const hitQ = !qNorm || text.includes(qNorm);
       const hitTags = tags.length === 0 || tags.every(t => i.tags.includes(t));
       return hitQ && hitTags;
     });
-    onFiltered(filtered);
+    setFiltered(next);
   };
 
   return (
-    <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-      <input
-        value={q}
-        onChange={(e)=>{ setQ(e.target.value); apply(e.target.value, selected); }}
-        placeholder="Search connectors…"
-        className="px-3 py-2 rounded-md border w-full md:w-96"
-        aria-label="Search connectors"
-      />
-      <div className="flex gap-2 flex-wrap">
-        {allTags.map(t => {
-          const active = selected.includes(t);
-          return (
+    <>
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <input
+          value={q}
+          onChange={e => {
+            setQ(e.target.value);
+            apply(e.target.value, selected);
+          }}
+          placeholder="Search connectors…"
+          className="px-3 py-2 rounded-md border w-full md:w-96"
+          aria-label="Search connectors"
+        />
+        <div className="flex gap-2 flex-wrap">
+          {allTags.map(t => {
+            const active = selected.includes(t);
+            return (
+              <button
+                key={t}
+                type="button"
+                onClick={() => {
+                  const nextSel = active
+                    ? selected.filter(x => x !== t)
+                    : [...selected, t];
+                  setSelected(nextSel);
+                  apply(q, nextSel);
+                }}
+                className={`text-xs px-2 py-1 rounded-full border ${active ? "bg-gray-900 text-white" : "bg-gray-50"}`}
+                aria-pressed={active}
+              >
+                {t}
+              </button>
+            );
+          })}
+          {selected.length > 0 && (
             <button
-              key={t}
               type="button"
-              onClick={()=>{
-                const next = active ? selected.filter(x=>x!==t) : [...selected, t];
-                setSelected(next); apply(q, next);
+              onClick={() => {
+                setSelected([]);
+                apply(q, []);
               }}
-              className={`text-xs px-2 py-1 rounded-full border ${active ? "bg-gray-900 text-white" : "bg-gray-50"}`}
-              aria-pressed={active}
+              className="text-xs px-2 py-1 rounded-full border"
             >
-              {t}
+              Clear
             </button>
-          );
-        })}
-        {selected.length > 0 && (
-          <button
-            type="button"
-            onClick={()=>{ setSelected([]); apply(q, []); }}
-            className="text-xs px-2 py-1 rounded-full border"
-          >
-            Clear
-          </button>
-        )}
+          )}
+        </div>
       </div>
-    </div>
+
+      <section className="mt-4 grid gap-4 md:grid-cols-2">
+        {filtered.map(c => (
+          <ConnectorCard key={c.slug} c={c} />
+        ))}
+      </section>
+    </>
   );
 }
+

--- a/apps/web/app/connectors/components/TagPill.tsx
+++ b/apps/web/app/connectors/components/TagPill.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+
+// Pill used to display filter tags; minimal styling to match existing UI.
+export default function TagPill({ children }: { children: ReactNode }) {
+  return (
+    <span className="inline-block text-xs px-2 py-1 rounded-full border bg-gray-50">
+      {children}
+    </span>
+  );
+}

--- a/apps/web/app/connectors/page.tsx
+++ b/apps/web/app/connectors/page.tsx
@@ -1,0 +1,34 @@
+import ConnectorCard from "./components/ConnectorCard";
+import SearchAndFilter from "./components/SearchAndFilter";
+import { CONNECTORS, type ConnectorMeta } from "./_data/connectors";
+
+export const metadata = {
+  title: "Connectors",
+  description: "Explore sustainability data sources integrated into Circl."
+};
+export const revalidate = 3600;
+
+// Server component renders connector hub; client filter keeps UX responsive.
+export default async function ConnectorsHub() {
+  const items: ConnectorMeta[] = CONNECTORS;
+  return (
+    <main className="container mx-auto max-w-6xl p-4 space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Connectors</h1>
+        <p className="text-sm text-gray-600">
+          Browse all data sources. Click a connector to open its page. Expand “How to use” for tips and sample queries.
+        </p>
+      </header>
+
+      <SearchAndFilter
+        items={items}
+        onFiltered={() => { /* client handles filtering */ }}
+      />
+
+      {/* Initial list rendered for non-JS / SEO; SearchAndFilter will adjust client-side */}
+      <section className="grid gap-4 md:grid-cols-2">
+        {items.map(c => <ConnectorCard key={c.slug} c={c} />)}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/connectors/page.tsx
+++ b/apps/web/app/connectors/page.tsx
@@ -1,4 +1,3 @@
-import ConnectorCard from "./components/ConnectorCard";
 import SearchAndFilter from "./components/SearchAndFilter";
 import { CONNECTORS, type ConnectorMeta } from "./_data/connectors";
 
@@ -20,15 +19,7 @@ export default async function ConnectorsHub() {
         </p>
       </header>
 
-      <SearchAndFilter
-        items={items}
-        onFiltered={() => { /* client handles filtering */ }}
-      />
-
-      {/* Initial list rendered for non-JS / SEO; SearchAndFilter will adjust client-side */}
-      <section className="grid gap-4 md:grid-cols-2">
-        {items.map(c => <ConnectorCard key={c.slug} c={c} />)}
-      </section>
+      <SearchAndFilter items={items} />
     </main>
   );
 }

--- a/apps/web/public/connectors/icons/borrow.svg
+++ b/apps/web/public/connectors/icons/borrow.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="7" width="18" height="13" />
+  <path d="M12 4v8m0 0l-3-3m3 3l3-3" />
+</svg>

--- a/apps/web/public/connectors/icons/cert.svg
+++ b/apps/web/public/connectors/icons/cert.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="8" r="5" />
+  <path d="M9 12l-2 9 5-3 5 3-2-9" />
+  <path d="M10 8l2 2 3-3" />
+</svg>

--- a/apps/web/public/connectors/icons/company.svg
+++ b/apps/web/public/connectors/icons/company.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="10" width="4" height="10" />
+  <rect x="10" y="4" width="4" height="16" />
+  <rect x="17" y="12" width="4" height="8" />
+</svg>

--- a/apps/web/public/connectors/icons/energy.svg
+++ b/apps/web/public/connectors/icons/energy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M13 3L4 14h7l-1 7 9-11h-7l1-7z" />
+</svg>

--- a/apps/web/public/connectors/icons/fair.svg
+++ b/apps/web/public/connectors/icons/fair.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 12l5-5 4 4 4-4 5 5" />
+  <path d="M3 12l5 5 4-4 4 4 5-5" />
+</svg>

--- a/apps/web/public/connectors/icons/food.svg
+++ b/apps/web/public/connectors/icons/food.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="13" r="7" />
+  <path d="M12 6c1-2 3-3 4-3" />
+</svg>

--- a/apps/web/public/connectors/icons/leaf.svg
+++ b/apps/web/public/connectors/icons/leaf.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2C7 2 4 7 4 11c0 6 8 11 8 11s8-5 8-11c0-4-3-9-8-9z" />
+  <path d="M12 22V8" />
+</svg>

--- a/apps/web/public/connectors/icons/market.svg
+++ b/apps/web/public/connectors/icons/market.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 7h18l-1 13H4L3 7z" />
+  <path d="M8 7V5a4 4 0 018 0v2" />
+</svg>

--- a/apps/web/public/connectors/icons/repair.svg
+++ b/apps/web/public/connectors/icons/repair.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 21l7.5-7.5m0 0a4.5 4.5 0 005.7-5.7L21 3l-3.8 3.8a4.5 4.5 0 00-5.7 5.7z" />
+  <path d="M9 17l4 4" />
+</svg>

--- a/changelog/connectors-hub-ui.md
+++ b/changelog/connectors-hub-ui.md
@@ -1,0 +1,1 @@
+feat: add connectors hub page with search and tips

--- a/docs/ops/verify-connectors-hub.md
+++ b/docs/ops/verify-connectors-hub.md
@@ -1,0 +1,9 @@
+# Connectors Hub – Manual Verification
+
+Short checklist to validate the Connectors Hub page before release.
+
+- `make ui-install`
+- `make ui-build`
+- Navigate to `/connectors` and ensure all listed connectors open their pages.
+- Test search (e.g., `monitor`) and tag filters (e.g., `certification`).
+- `mkdocs build --strict` for docs sanity.


### PR DESCRIPTION
## Summary
- scaffold connectors metadata, cards and filters
- expose searchable connectors hub with usage tips and icons
- document manual verification steps

## Testing
- `make ui-install`
- `make ui-build` *(fails: vite: not found)*
- `pnpm -C apps/web lint` *(fails: Definition for rule '@next/next/no-img-element' was not found)*
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68be2f49ad388321953de6abf9c76d1e