### PR TITLE
fix(web): add connectors path fallback in Nav

### DIFF
--- a/apps/web/app/(site)/_components/Nav.tsx
+++ b/apps/web/app/(site)/_components/Nav.tsx
@@ -4,7 +4,12 @@ import NavClient from './NavClient';
 
 // Server component reads available connector pages and forwards them to the client.
 export default function Nav() {
-  const base = path.join(process.cwd(), 'app/connectors');
+  const candidates = ['app/connectors', 'apps/web/app/connectors'];
+  // Prefer app/connectors for local packages; fall back to apps/web/app/connectors when run from repo root
+  const base =
+    candidates
+      .map((p) => path.join(process.cwd(), p))
+      .find((p) => fs.existsSync(p)) ?? path.join(process.cwd(), candidates[0]);
   let connectors: string[] = [];
   try {
     connectors = fs

--- a/changelog/nav-connectors-fallback.md
+++ b/changelog/nav-connectors-fallback.md
@@ -1,0 +1,1 @@
+fix: handle connectors path fallback in Nav (#PR)


### PR DESCRIPTION
## Summary
- resolve connectors path in Nav by checking `app/connectors` then falling back to `apps/web/app/connectors`
- document dual-path lookup
- add changelog entry

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68beca170ef0832192b13bbde7602f11