### PR TITLE
feat(deploy): Cloudflare Pages + adapter + optional auth

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -1,0 +1,31 @@
+name: cloudflare-pages
+
+on:
+  push:
+    branches: [main]
+    paths: ["apps/web/**"]
+  pull_request:
+    paths: ["apps/web/**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - name: Install deps
+        run: pnpm -w install
+      - name: Build web app
+        working-directory: apps/web
+        run: pnpm build
+      - name: Cloudflare adapter build
+        working-directory: apps/web
+        run: pnpm cf:build

--- a/apps/web/.cfignore
+++ b/apps/web/.cfignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+.git
+.vscode
+.vercel
+.DS_Store

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,36 +1,44 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-// Preview-only Basic Auth middleware
-// Why: guard non-production deployments when preview credentials are set
+// Optional Basic Auth middleware
+// Why: gate preview deployments and Cloudflare Pages when env flags are set
 const isProd = process.env.VERCEL_ENV === 'production';
+const usingAppAuth = process.env.APP_BASIC_AUTH === '1';
 
 export function middleware(req: NextRequest) {
-  // Skip in production to avoid affecting live traffic
-  if (isProd) return NextResponse.next();
+  const enablePreviewAuth = !isProd && !usingAppAuth;
 
-  const user = process.env.PREVIEW_AUTH_USER || '';
-  const pass = process.env.PREVIEW_AUTH_PASS || '';
-  // If credentials are missing, bypass auth to avoid accidental lockouts
-  if (!user || !pass) return NextResponse.next();
+  const user = usingAppAuth
+    ? process.env.APP_BASIC_USER || ''
+    : process.env.PREVIEW_AUTH_USER || '';
+  const pass = usingAppAuth
+    ? process.env.APP_BASIC_PASS || ''
+    : process.env.PREVIEW_AUTH_PASS || '';
+
+  // Skip when auth isn't enabled or credentials missing
+  if (!(usingAppAuth || enablePreviewAuth) || !user || !pass) {
+    return NextResponse.next();
+  }
 
   const header = req.headers.get('authorization') || '';
   const [scheme, encoded] = header.split(' ');
   if (scheme !== 'Basic' || !encoded) {
-    // Prompt for credentials when auth header absent or malformed
+    // Trigger browser auth prompt when header absent or malformed
     return new NextResponse('Authentication required', {
       status: 401,
-      headers: { 'WWW-Authenticate': 'Basic realm="Preview"' },
+      headers: { 'WWW-Authenticate': 'Basic realm="Protected"' },
     });
   }
 
   const [u, p] = Buffer.from(encoded, 'base64').toString().split(':');
-  // Allow only when provided credentials match preview env values
   if (u === user && p === pass) return NextResponse.next();
 
   return new NextResponse('Forbidden', { status: 403 });
 }
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|robots.txt|.*\\.(?:png|jpg|jpeg|gif|svg|webp|ico)$).*)',
+  ],
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,9 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run --exclude tests/e2e/**",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "cf:build": "npx @cloudflare/next-on-pages",
+    "cf:preview": "wrangler pages dev ./.vercel/output/static --port=8788 || true"
   },
   "dependencies": {
     "next": "^14.2.3",
@@ -28,6 +30,8 @@
     "@playwright/test": "^1.44.0",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.3"
+    "tailwindcss": "^3.4.3",
+    "@cloudflare/next-on-pages": "latest",
+    "wrangler": "latest"
   }
 }

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -1,0 +1,3 @@
+name = "circl-web"
+compatibility_date = "2024-09-01"
+pages_build_output_dir = ".vercel/output/static"

--- a/docs/ops/README_DEPLOY.md
+++ b/docs/ops/README_DEPLOY.md
@@ -1,0 +1,34 @@
+# Cloudflare Pages Deployment
+
+This guide covers deploying the `apps/web` Next.js app to Cloudflare Pages with an optional Zero Trust gate.
+
+## Build Configuration
+
+In the monorepo root run:
+
+```bash
+pnpm -w install
+pnpm --filter @circl/web build
+pnpm --filter @circl/web cf:build
+```
+
+The Cloudflare adapter outputs to `.vercel/output/static`. Set the Pages project build output directory to this path and use `pnpm --filter @circl/web build` as the build command.
+
+## Environment Variables
+
+| Variable | Purpose |
+| --- | --- |
+| `APP_BASIC_AUTH` | Enable Basic Auth when set to `1` |
+| `APP_BASIC_USER` | Username for Basic Auth |
+| `APP_BASIC_PASS` | Password for Basic Auth |
+
+## Zero Trust Gate
+
+Protect preview or production deployments by enabling Cloudflare Zero Trust and toggling `APP_BASIC_AUTH`. Assign access policies for teams or users who may bypass the gate.
+
+## Cut-over / Rollback
+
+1. Deploy to a new Pages project and verify via `pnpm cf:preview`.
+2. Update DNS to point to the Pages domain when ready.
+3. To rollback, restore the previous DNS record or redeploy the prior Vercel build.
+


### PR DESCRIPTION
## Summary
- add Cloudflare Pages adapter deps and scripts
- add wrangler config and ignore
- add optional env-gated Basic Auth middleware
- add Cloudflare build check workflow
- document Pages deployment and Zero Trust

## Testing
- `pnpm --filter @circl/web build`
- `pnpm --filter @circl/web cf:build` *(fails: build aborted? partial due to environment)*
- `pnpm --filter @circl/web test`
- `mkdocs build --strict` *(fails: Aborted with 1 warnings in strict mode)*


------
https://chatgpt.com/codex/tasks/task_e_68bed2d7cf2083219691c2e5937a2663